### PR TITLE
Production serve static files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /usr/src/app
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
+ENV DEBUG=False
 
 RUN apk add --no-cache tini gcc musl-dev libpq-dev
 

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -105,7 +105,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    # 'whitenoise.middleware.WhiteNoiseMiddleware',
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -207,12 +207,19 @@ LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = "/static/"
-# STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
 
 # for whitenoise
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+}
+
+# Use ManifestStaticFilesStorage when not in debug mode
+if not DEBUG:
+    STORAGES["staticfiles"] =  {"BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"}
+
 
 # Redirect to home URL after login (Default redirects to /accounts/profile/)
 LOGIN_REDIRECT_URL = "/"
@@ -258,7 +265,6 @@ SENDGRID_TRACK_CLICKS_HTML = False
 
 # Calfeed settings
 DYNAMIC_CALFEED = env('CALFEED_DYNAMIC_CALFEED', default=False) # True to generate calfeed on demand; False for disk cache
-DEFAULT_FILE_STORAGE = env('CALFEED_DEFAULT_FILE_STORAGE', default='django.core.files.storage.FileSystemStorage')
 CALFEED_BASEDIR = env('CALFEED_CALFEED_BASEDIR', default='')
 
 MESSAGE_TAGS = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ graphene==2.1.9
 graphene-django==2.16.0
 graphql-core==2.3.2
 graphql-relay==2.0.1
+gunicorn==21.2.0
 icalendar==4.0.7
 isort==5.9.3
 Jinja2==3.1.3
@@ -28,6 +29,7 @@ lazy-object-proxy==1.6.0
 Markdown==3.3.4
 MarkupSafe==2.0.1
 mccabe==0.6.1
+packaging==23.2
 pipupgrade==1.9.0
 promise==2.3
 protobuf==3.18.3


### PR DESCRIPTION
Closes #109
Closes #225 

Switch to gunicorn for faster request servicing. Switch to Whitenoise for serving static files via Gunicorn.