### PR TITLE
Reduce workload on queued tasks

### DIFF
--- a/go3/settings.py
+++ b/go3/settings.py
@@ -214,14 +214,13 @@ LOGOUT_REDIRECT_URL = "/accounts/login"
 Q_CLUSTER = {
     "name": "DjangORM",
     "workers": 1,
-    "timeout": 90,
-    "retry": 120,
-    "queue_limit": 50,
-    "bulk": 10,
+    "timeout": 30,
+    "retry": 60,
     "orm": "default",
     "sync": _testing,
     "catch_up": False,  # don't run scheduled tasks many times if we come back from an extended downtime
     "poll": 10, # turn down the poll rate - doesn't need to be 5 times per second!
+    "ack_failure": True, # Do not auto-retry tasks, prevent storms or spam
 }
 
 

--- a/lib/email.py
+++ b/lib/email.py
@@ -13,6 +13,7 @@ DEFAULT_SUBJECT = 'Message from Gig-O-Matic'
 
 def send_messages_async(messages):
     # Can accept an iterable, so we need to make it a list for serialization
+    # ack_failure=True prevents spamming people with taks retries
     return async_task('lib.email.do_send_messages_async', list(messages), ack_failure=True)
 
 def do_send_messages_async(messages):

--- a/member/helpers.py
+++ b/member/helpers.py
@@ -91,7 +91,7 @@ def delete_member(request, pk):
 
     return redirect('home')
 
-def send_invite(invite):
+def send_invite_async(invite):
     context = {
         'new': (Member.objects.filter(email=invite.email).count() == 0),
         'invite_id': invite.id,

--- a/member/signals.py
+++ b/member/signals.py
@@ -18,6 +18,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django_q.tasks import async_task
 from .models import Member, MemberPreferences, Invite, EmailConfirmation
+from .helpers import send_invite_async
 from go3.settings import IN_ETL
 
 # signals to make sure a set of preferences is created for every user
@@ -33,7 +34,7 @@ def handle_user_preferences(sender, instance, created, **kwargs):
 @receiver(post_save, sender=Invite)
 def send_invite(sender, instance, created, **kwargs):
     if created:
-        async_task('member.helpers.send_invite', instance)
+        send_invite_async(instance)
 
 @receiver(post_save, sender=EmailConfirmation)
 def send_email_conf(sender, instance, created, **kwargs):


### PR DESCRIPTION
This investigation was started because invitations were being sent and resent (and resent...) every 5 minutes. My suspicion is that the model callback task was failing and getting re-enqueued. Looking at the previous implementation, it queued a task to queue a task. This PR simplifies that to just one task per invitation email.

While I was at it, I changed the Django-Q behavior to not attempt to retry failed tasks by default. This is definitely important for email so we don't accidentally spam people when things don't work right, and I think this default is a safe one in general.