### PR TITLE
Let enter key submit forms

### DIFF
--- a/templates/base/go3base.html
+++ b/templates/base/go3base.html
@@ -161,18 +161,6 @@
         })
     </script>
 
-<script type="text/javascript">
-
-function stopRKey(evt) {
-  var evt = (evt) ? evt : ((event) ? event : null);
-  var node = (evt.target) ? evt.target : ((evt.srcElement) ? evt.srcElement : null);
-  if (evt.keyCode == 13 && (node.type != "textarea") && (node.type != "submit"))  {return false;}
-}
-
-document.onkeypress = stopRKey;
-
-</script>
-
     {% block localscripts %}
     {% endblock localscripts %}
     {% block navbarscripts %}


### PR DESCRIPTION
I noticed that I was not able to type my username & password and then press enter to log in. This snippet of JS is the culprit. I'm sure it was added to fix a problem at some point, but in my testing I can't find any screen where pressing the enter key does something unexpected. I think we should allow default form behavior, and if an issue does come up, figure out a more targeted fix.