### PR TITLE
Remove reference to missing stylesheet

### DIFF
--- a/templates/agenda/calendar.html
+++ b/templates/agenda/calendar.html
@@ -5,7 +5,6 @@
 {% block headcontent %}
         <!-- Custom styles for calendar -->
         <link href='/static/fullcalendar/lib/main.css' rel='stylesheet' />
-        <link href='/fullcalendar/fullcalendar.print.css' rel='stylesheet' media='print' />
 {% endblock headcontent %}
 
 


### PR DESCRIPTION
It looks like FullCalendar got upgraded with the move to GO3. This file is no longer part of the distribution, and print styles are included in the main CSS