### PR TITLE
Convert print statements to debug logs

### DIFF
--- a/band/apps.py
+++ b/band/apps.py
@@ -23,5 +23,5 @@ class BandConfig(AppConfig):
 
     @staticmethod
     def ready():
-        logging.debug("loaded band signals")
+        logging.debug("loading band signals")
         from . import signals

--- a/gig/apps.py
+++ b/gig/apps.py
@@ -22,5 +22,5 @@ class GigConfig(AppConfig):
 
     @staticmethod
     def ready():
-        logging.debug("loaded gig signals")
+        logging.debug("loading gig signals")
         from . import signals

--- a/member/apps.py
+++ b/member/apps.py
@@ -16,6 +16,7 @@
 """
 
 from django.apps import AppConfig
+import logging
 
 
 class MemberConfig(AppConfig):
@@ -23,5 +24,5 @@ class MemberConfig(AppConfig):
 
     @staticmethod
     def ready():
-        print("loaded member signals") #todo make debug
+        logging.debug("loading member signals")
         from . import signals

--- a/motd/apps.py
+++ b/motd/apps.py
@@ -15,6 +15,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 from django.apps import AppConfig
+import logging
 
 
 class MotdConfig(AppConfig):
@@ -22,5 +23,5 @@ class MotdConfig(AppConfig):
 
     @staticmethod
     def ready():
-        print("loaded motd signals") # todo make debug pring
+        logging.debug("loading motd signals")
         from . import signals


### PR DESCRIPTION
These `print()` statements were corrupting `manage.py dumpdata` exports because they were writing to STDOUT