### PR TITLE
Fix showing all member plans on gig detail page

### DIFF
--- a/gig/views.py
+++ b/gig/views.py
@@ -70,6 +70,8 @@ class DetailView(LoginRequiredMixin, UserPassesTestMixin, generic.DetailView):
 
         context['plan_list'] = [x.value for x in PlanStatusChoices]
 
+        context['gig_ordered_member_plans'] = self.object.member_plans.order_by('section_id')
+
         if self.object.address:
             if url_validate(self.object.address):
                 context['address_string'] = self.object.address

--- a/templates/gig/gig_detail.html
+++ b/templates/gig/gig_detail.html
@@ -243,7 +243,7 @@
                         </div>
                     </div>
                 {% endif %}
-                {% regroup gig.member_plans.all by section as plans_by_section %}
+                {% regroup gig_ordered_member_plans by section as plans_by_section %}
                 {% for section in band.sections.all %}
                     <div class="row" style="padding-top: 5px; padding-bottom: 5px; {% cycle '' 'background:#f5f5f5;' %}">
                         {% if band.sections.all|length > 1 %}


### PR DESCRIPTION
Before this change, only one band member response per section would display. After this change, all plans for all members are displayed.

Order member plans so `regroup` works as expected

This took me a while to figure out because I missed the requirement that the regroup input is already sorted by the grouper. Thank you [to this StackOverflow answer](https://stackoverflow.com/questions/17194147/django-regroup-templatetag-does-not-group-properly)