### PR TITLE
Hide "None" comments if comment is not supplied

### DIFF
--- a/templates/gig/gig_plan_edit.html
+++ b/templates/gig/gig_plan_edit.html
@@ -96,18 +96,18 @@
                         </div>
                     {% endif %}
                 {% endif %}
-                <a href="#" class="comment-thing" id="username" data-type="text" data-pk="{{plan.id}}" data-url="/gig/plan/{{ plan.id }}/comment" data-title="">{{plan.comment|default_if_none:""}}</a>
+                <a href="#" class="comment-thing" id="username" data-type="text" data-pk="{{plan.id}}" data-url="/gig/plan/{{ plan.id }}/comment" data-title="">{{plan.comment|default:""}}</a>
             </div>
         {% else %}
             <div class="col-8" style="display:flex; align-items:center;" >
                 <span style="padding-right:10px">{% include "gig/plan_icon.html" with plan_value=plan.status %}</span>
                 {{ plan.feedback_string }}
-                {{ plan.comment }}
+                {{ plan.comment|default:"" }}
             </div>
         {% endif %}
     {% else %}
         <div class="col-8" style="display:flex; align-items:center;" >
-            <span style="padding-right:10px">{% include "gig/plan_icon.html" with plan_value=plan.status %}</span> {{ plan.feedback_string }} {{ plan.comment }}
+            <span style="padding-right:10px">{% include "gig/plan_icon.html" with plan_value=plan.status %}</span> {{ plan.feedback_string }} {{ plan.comment|default:"" }}
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
Use `default` instead of `default_if_none` because of this note in [the docs](https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#default-if-none):

> Note that if an empty string is given, the default value will not be used. Use the [default](https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#std-templatefilter-default) filter if you want to fallback for empty strings.

Before:
![Screenshot 2024-03-03 at 6 28 58 PM](https://github.com/Gig-o-Matic/GO3/assets/167131/b29f3e74-f101-47c7-a08f-0839613fff0e)

After:
![Screenshot 2024-03-03 at 6 29 32 PM](https://github.com/Gig-o-Matic/GO3/assets/167131/1f28ee2e-cb30-4eed-a707-a8e23ac18fca)
