### PR TITLE
Stop showing trashed gigs on calendar

### DIFF
--- a/agenda/helpers.py
+++ b/agenda/helpers.py
@@ -77,6 +77,8 @@ def calendar_events(request, pk):
     events = []
     multiband = len(user_assocs) > 1
     for g in the_gigs:
+        if (g.is_in_trash):
+            continue
         gig = {}
         gig['title'] = f'{g.band.name} - {g.title}' if multiband else g.title
         gig['start'] = str(g.date)

--- a/agenda/helpers.py
+++ b/agenda/helpers.py
@@ -78,8 +78,6 @@ def calendar_events(request, pk):
     events = []
     multiband = len(user_assocs) > 1
     for g in the_gigs:
-        if (g.is_in_trash):
-            continue
         gig = {}
         gig['title'] = f'{g.band.name} - {g.title}' if multiband else g.title
         gig['start'] = str(g.date)

--- a/agenda/helpers.py
+++ b/agenda/helpers.py
@@ -72,6 +72,7 @@ def calendar_events(request, pk):
         date__gte=start,
         band__in=[a.band for a in user_assocs],
         hide_from_calendar=False,
+        trashed_date__isnull=True
     )
 
     events = []


### PR DESCRIPTION
Attempting to fix https://github.com/Gig-o-Matic/GO3/issues/246. 

Tested this out by  creating two gigs set in the future. Confirmed both appeared on calendar. Moved first gig to trash, then confirmed the first gig no longer appeared on the calendar. 
Images below
<img width="773" alt="Screenshot 2024-03-04 at 11 22 04 PM" src="https://github.com/Gig-o-Matic/GO3/assets/7034143/abe71025-1c05-4acc-948e-8b367d21fa1b">
<img width="829" alt="Screenshot 2024-03-04 at 11 22 11 PM" src="https://github.com/Gig-o-Matic/GO3/assets/7034143/5617c69b-166b-4c8f-9d42-a1d602dc9c87">
<img width="1082" alt="Screenshot 2024-03-04 at 11 22 16 PM" src="https://github.com/Gig-o-Matic/GO3/assets/7034143/5cff0fb7-29e3-4cbb-bbaf-955d60a79e38">
