### PR TITLE
Add CSS fix for Safari iOS language selection text

### DIFF
--- a/static/css/gigo.css
+++ b/static/css/gigo.css
@@ -126,6 +126,11 @@ a {
   z-index:9999;
 }
 
+.dropdown-menu .lang-input {
+  /* Needed for Safari on iOS 17 */
+  color: #09121c;
+}
+
 .h5, h5 {
     font-size: 1.2rem;
 }


### PR DESCRIPTION
This menu works fine on desktop, but for some reason shows up as white text on a white background on iOS.

Closes #270 
![310937716-e3ac4d24-9fbd-43cd-b2c4-dfbfd1042fc0](https://github.com/Gig-o-Matic/GO3/assets/167131/b3787956-1be7-44f4-9a23-8b9995523800)

![IMG_6F433ABC478E-1](https://github.com/Gig-o-Matic/GO3/assets/167131/460b4261-a073-4937-88d8-6920912a384c)
