### PR TITLE
Mobile-friendly gig status comments

### DIFF
--- a/static/css/gigo.css
+++ b/static/css/gigo.css
@@ -260,3 +260,13 @@ ul.errorlist {
   border-color:#999;
   text-align: center;
 }
+
+/* x-editable interface
+-------------------------------------------------- */
+.editable-input input[type="text"], .editable-input textarea {
+    width: 100%;
+}
+
+.editable-container.editable-inline {
+    width: 100%
+}

--- a/static/js/plan_buttons.js
+++ b/static/js/plan_buttons.js
@@ -29,3 +29,13 @@ function init_plan_comments(token) {
 $(document).ready(function() {
 });
 
+$.fn.editableform.template = `\
+<form class="form-inline editableform">
+    <div class="control-group w-100">
+         <div class="d-md-flex justify-content-end">
+            <div class="editable-input d-block flex-shrink-1 w-100 mb-2 mb-md-0"></div>
+            <div class="editable-buttons d-block text-right"></div>
+        </div>
+         <div class="editable-error-block"></div>
+    </div> 
+</form>`

--- a/static/js/plan_buttons.js
+++ b/static/js/plan_buttons.js
@@ -32,10 +32,14 @@ $(document).ready(function() {
 $.fn.editableform.template = `\
 <form class="form-inline editableform">
     <div class="control-group w-100">
-         <div class="d-md-flex justify-content-end">
-            <div class="editable-input d-block flex-shrink-1 w-100 mb-2 mb-md-0"></div>
+         <div class="d-md-flex justify-content-end align-items-stretch">
+            <div class="editable-input d-block flex-shrink-1 w-100 mb-1 mb-md-0"></div>
             <div class="editable-buttons d-block text-right"></div>
         </div>
          <div class="editable-error-block"></div>
     </div> 
 </form>`
+
+$.fn.editableform.buttons = `\
+<button type="submit" class="editable-submit btn btn-sm btn-primary h-100">ok</button>
+<button type="button" class="editable-cancel btn btn-sm btn-secondary h-100 ml-0">cancel</button>`

--- a/templates/gig/gig_plan_edit.html
+++ b/templates/gig/gig_plan_edit.html
@@ -83,7 +83,7 @@
                                 hx-get="{% url 'plan-update-section' pk=plan.id val=section.id %}"
                                 hx-ext="update-dropdown"
                                 hx-target="#sel-{{ plan.id }} span"
-                                hx-indicator="#sel-{{ plan.id }}"">
+                                hx-indicator="#sel-{{ plan.id }}">
                                     {{ section.name }}
                                 </a>
                     {% comment %}


### PR DESCRIPTION
This addresses #241 by pushing the comment buttons below the text field on smaller screens. Also added bootstrap styles to the buttons.

![Screenshot 2024-03-11 at 13-56-34 Gig-o-Matic Gig Info](https://github.com/Gig-o-Matic/GO3/assets/20374950/d92f5df2-cae6-42c0-bb65-bf74736a8792)

![Screenshot 2024-03-11 at 13-56-25 Gig-o-Matic Gig Info](https://github.com/Gig-o-Matic/GO3/assets/20374950/aa209734-bd58-45e7-9cc0-c8e7589ecb15)