### PR TITLE
Permissions cleanup

### DIFF
--- a/band/views.py
+++ b/band/views.py
@@ -5,7 +5,7 @@ from django.views.generic.edit import UpdateView as BaseUpdateView
 from django.views.generic.base import TemplateView
 from django.urls import reverse
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.mixins import LoginRequiredMixin, AccessMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, render
 from .models import Band, Assoc, Section
@@ -13,6 +13,7 @@ from .forms import BandForm
 from .util import AssocStatusChoices, BandStatusChoices
 from member.models import Invite
 from member.util import MemberStatusChoices
+from member.helpers import has_manage_band_permission
 from stats.helpers import get_band_stats, get_gigs_over_time_stats
 import json
 from django.utils.safestring import SafeString
@@ -20,17 +21,13 @@ from datetime import datetime
 from django.utils.translation import gettext_lazy as _
 from go3.settings import URL_BASE
 
-class BandMemberRequiredMixin(AccessMixin):
+class BandMemberRequiredMixin(UserPassesTestMixin):
     """Verify that the current user is authenticated."""
 
-    def dispatch(self, request, *args, **kwargs):
-        band = get_object_or_404(Band, pk=kwargs['pk'])
-        is_band_member = Assoc.objects.filter(
-            member=request.user, band=band, status=AssocStatusChoices.CONFIRMED).count() == 1
-        if not (is_band_member or request.user.is_superuser):
-            return self.handle_no_permission()
-        return super().dispatch(request, *args, **kwargs)
-
+    def test_func(self):
+        # can only edit the band if you're logged in and an admin or superuser
+        band = get_object_or_404(Band, id=self.kwargs['pk'])
+        return self.request.user and band.has_member(self.request.user)
 
 class BandList(LoginRequiredMixin, generic.ListView):
     queryset = Band.objects.filter(
@@ -88,9 +85,14 @@ class DetailView(generic.DetailView):
         return reverse('member-detail', kwargs={'pk': self.object.id})
 
 
-class UpdateView(LoginRequiredMixin, BandMemberRequiredMixin, BaseUpdateView):
+class UpdateView(LoginRequiredMixin, UserPassesTestMixin, BaseUpdateView):
     model = Band
     form_class = BandForm
+
+    def test_func(self):
+        # can only edit the band if you're logged in and an admin or superuser
+        band = get_object_or_404(Band, id=self.kwargs['pk'])
+        return has_manage_band_permission(self.request.user, band)
 
     def get_success_url(self):
         return reverse('band-detail', kwargs={'pk': self.object.id})

--- a/band/views.py
+++ b/band/views.py
@@ -22,12 +22,15 @@ from django.utils.translation import gettext_lazy as _
 from go3.settings import URL_BASE
 
 class BandMemberRequiredMixin(UserPassesTestMixin):
-    """Verify that the current user is authenticated."""
+    """Verify that the current user is authenticated and is a member of this band (or is the superuser)."""
 
     def test_func(self):
         # can only edit the band if you're logged in and an admin or superuser
         band = get_object_or_404(Band, id=self.kwargs['pk'])
-        return self.request.user and band.has_member(self.request.user)
+        return self.request.user and (
+            self.request.user.is_superuser or
+            band.has_member(self.request.user)
+        )
 
 class BandList(LoginRequiredMixin, generic.ListView):
     queryset = Band.objects.filter(

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -1066,7 +1066,7 @@ class GigSecurityTest(GigTestBase):
         self.assertEqual(response.status_code, 403) # fail if we can't create gigs
 
         c = Client()
-        response = c.get(reverse("gig-detail", args=[self.band.id]))
+        response = c.get(reverse("gig-create", args=[self.band.id]))
         self.assertEqual(response.status_code, 302) # fail if we're logged out
 
     def test_gig_edit_access(self):

--- a/gig/views.py
+++ b/gig/views.py
@@ -28,26 +28,10 @@ from .forms import GigForm
 from .util import PlanStatusChoices
 from band.models import Band, Assoc
 from gig.helpers import notify_new_gig
+from member.helpers import has_band_admin, has_manage_gig_permission, has_create_gig_permission, has_comment_permission
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from validators import url as url_validate
 import pytz
-
-def has_band_admin(user, band):
-    return user and user.is_superuser or band.is_admin(user)
-
-def has_manage_gig_permission(user, band):
-    return user and (
-        has_band_admin(user, band) or
-        (band.has_member(user) and band.anyone_can_manage_gigs))
-
-def has_create_gig_permission(user, band):
-    return user and (
-        has_band_admin(user, band) or
-        (band.has_member(user) and band.anyone_can_create_gigs))
-
-def has_comment_permission(user, gig):
-    return user and (
-        user.is_superuser or gig.band.has_member(user))
 
 
 class DetailView(LoginRequiredMixin, UserPassesTestMixin, generic.DetailView):

--- a/gig/views.py
+++ b/gig/views.py
@@ -32,19 +32,22 @@ from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from validators import url as url_validate
 import pytz
 
+def has_band_admin(user, band):
+    return user and user.is_superuser or band.is_admin(user)
+
+def has_manage_gig_permission(user, band):
+    return user and (
+        has_band_admin(user, band) or
+        (band.has_member(user) and band.anyone_can_manage_gigs))
+
+def has_create_gig_permission(user, band):
+    return user and (
+        has_band_admin(user, band) or
+        (band.has_member(user) and band.anyone_can_create_gigs))
 
 def has_comment_permission(user, gig):
-    return user and Assoc.objects.filter(member=user, band=gig.band).count() == 1
-
-def has_band_admin(user, band):
-    return user and band.is_admin(user)
-
-def has_manage_permission(user, band):
-    return user and (user.is_superuser or band.anyone_can_manage_gigs or band.is_admin(user))
-
-
-def has_create_permission(user, band):
-    return user and (user.is_superuser or band.anyone_can_create_gigs or band.is_admin(user))
+    return user and (
+        user.is_superuser or gig.band.has_member(user))
 
 
 class DetailView(LoginRequiredMixin, UserPassesTestMixin, generic.DetailView):
@@ -66,9 +69,7 @@ class DetailView(LoginRequiredMixin, UserPassesTestMixin, generic.DetailView):
         context = super().get_context_data(**kwargs)
         context['user_has_band_admin'] = has_band_admin(
             self.request.user, self.object.band)
-        context['user_can_edit'] = has_manage_permission(
-            self.request.user, self.object.band)
-        context['user_can_create'] = has_create_permission(
+        context['user_has_manage_gig_permission'] = has_manage_gig_permission(
             self.request.user, self.object.band)
 
         tz = pytz.timezone(self.object.band.timezone)
@@ -103,24 +104,17 @@ class DetailView(LoginRequiredMixin, UserPassesTestMixin, generic.DetailView):
         return context
 
 
-class CreateView(LoginRequiredMixin, generic.CreateView):
+class CreateView(LoginRequiredMixin, UserPassesTestMixin, generic.CreateView):
     model = Gig
     form_class = GigForm
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    # cribbed from UserPassesTestMixin
-    def dispatch(self, request, *args, **kwargs):
-        user_test_result = self.test_func()
-        if not user_test_result:
-            return self.handle_no_permission()
-        return super().dispatch(request, *args, **kwargs)
-
     def test_func(self):
         # can only create the gig if you're logged in and in the band        
         band = get_object_or_404(Band, id=self.kwargs['bk'])
-        return band.has_member(self.request.user) and has_create_permission(self.request.user, band)
+        return has_create_gig_permission(self.request.user, band)
 
     def get_success_url(self):
         return reverse('gig-detail', kwargs={'pk': self.object.id})
@@ -143,7 +137,7 @@ class CreateView(LoginRequiredMixin, generic.CreateView):
 
     def form_valid(self, form):
         band = Band.objects.get(id=self.kwargs['bk'])
-        if not has_create_permission(self.request.user, band):
+        if not has_manage_gig_permission(self.request.user, band):
             return HttpResponseForbidden()
 
         # there's a new gig; link it to the band
@@ -158,21 +152,14 @@ class CreateView(LoginRequiredMixin, generic.CreateView):
         return result
 
 
-class UpdateView(LoginRequiredMixin, generic.UpdateView):
+class UpdateView(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
     model = Gig
     form_class = GigForm
-
-    # cribbed from UserPassesTestMixin
-    def dispatch(self, request, *args, **kwargs):
-        user_test_result = self.test_func()
-        if not user_test_result:
-            return self.handle_no_permission()
-        return super().dispatch(request, *args, **kwargs)
 
     def test_func(self):
         # can only edit the gig if you're logged in and in the band        
         gig = get_object_or_404(Gig, id=self.kwargs['pk'])
-        return gig.band.has_member(self.request.user) and has_manage_permission(self.request.user, gig.band)
+        return has_manage_gig_permission(self.request.user, gig.band)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -186,8 +173,7 @@ class UpdateView(LoginRequiredMixin, generic.UpdateView):
         pass
 
     def form_valid(self, form):
-
-        if not has_manage_permission(self.request.user, self.object.band):
+        if not has_manage_gig_permission(self.request.user, self.object.band):
             return HttpResponseForbidden()
 
         result = super(UpdateView, self).form_valid(form)
@@ -199,7 +185,7 @@ class UpdateView(LoginRequiredMixin, generic.UpdateView):
         return result
 
 
-class DuplicateView(UserPassesTestMixin, CreateView):
+class DuplicateView(CreateView):
 
     def test_func(self):
         if not self.request.user.is_authenticated:
@@ -230,10 +216,11 @@ class CommentsView(UserPassesTestMixin, TemplateView):
     template_name = 'gig/gig_comments.html'
 
     def test_func(self):
-        if not self.request.user.is_authenticated:
+        user = self.request.user
+        if not user.is_authenticated:
             return self.handle_no_permission()
         gig = get_object_or_404(Gig, id=self.kwargs['pk'])
-        return gig.band.has_member(self.request.user)
+        return gig.band.has_member(user) or user.is_superuser
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/member/helpers.py
+++ b/member/helpers.py
@@ -156,3 +156,25 @@ def calfeed(request, pk):
         return hr
 
     return HttpResponse(tf)
+
+
+# helpers to define member permissions for various things
+def has_band_admin(user, band):
+    return user and user.is_superuser or band.is_admin(user)
+
+def has_manage_gig_permission(user, band):
+    return user and (
+        has_band_admin(user, band) or
+        (band.has_member(user) and band.anyone_can_manage_gigs))
+
+def has_create_gig_permission(user, band):
+    return user and (
+        has_band_admin(user, band) or
+        (band.has_member(user) and band.anyone_can_create_gigs))
+
+def has_comment_permission(user, gig):
+    return user and (
+        user.is_superuser or gig.band.has_member(user))
+
+def has_manage_band_permission(user, band):
+    return user and has_band_admin(user,band)

--- a/templates/gig/gig_detail.html
+++ b/templates/gig/gig_detail.html
@@ -22,16 +22,12 @@
                     <div class="col-4">
                         {% trans "Info" %}
                     </div>
-                    {% if user_can_edit and gig.is_in_trash == False and gig.is_archived == False %}
+                    {% if user_has_manage_gig_permission and gig.is_in_trash == False and gig.is_archived == False %}
                         <div class="ml-auto">
-                            {% if user_can_edit %}
-                                <a class="btn btn-primary btn-sm" href="{% url 'gig-update' gig.id %}">{% trans "Edit" %}</a>
-                            {% endif %}
-                            {% if user_can_create %}
-                                <a class="btn btn-primary btn-sm" href="{% url 'gig-duplicate' gig.id %}">{% trans "Duplicate" %}</a>
-                            {% endif %}
+                            <a class="btn btn-primary btn-sm" href="{% url 'gig-update' gig.id %}">{% trans "Edit" %}</a>
+                            <a class="btn btn-primary btn-sm" href="{% url 'gig-duplicate' gig.id %}">{% trans "Duplicate" %}</a>
                         </div>
-                {% endif %}
+                    {% endif %}
                 </div>
             </div>
             <div class="card-body">
@@ -213,7 +209,7 @@
                         <span id="simpleon">{% trans "Show Committed" %}</span>
                         </a>
 
-                        {% if user_can_edit %}
+                        {% if user_has_manage_gig_permission %}
                             {% if not gig.was_reminded %}
                             <span id="showremind"><a href="#" onclick="sendreminder(); return false;" class="btn btn-sm btn-secondary"><i class="fas fa-envelope"></i>
                             	{% trans "Remind" %}
@@ -316,7 +312,7 @@ function simpleswitch() {
     setsimple()
 }
 
-{% if user_can_edit %}
+{% if user_has_manage_gig_permission %}
 function sendreminder() {
 	$('#showremind').hide();
 	$('#hideremind').show();
@@ -349,7 +345,7 @@ $(document).ready(function() {
 
     updatecounts();
     setsimple();
-    {% if user_can_edit %}
+    {% if user_has_manage_gig_permission %}
         {% if not gig.was_reminded %}
         	$('#showremind').show();
         	$('#hideremind').hide();


### PR DESCRIPTION
This started as an attempt to address #304 and turned into a permissions refactor.

- Simplify and centralize the checking of administrative permissions - superuser is always a band admin
- Rename template variables to match model attributes for consistency
- Use the UserPassesTestMixin directly instead of cribbing its code


Closes #304 