### PR TITLE
made the pagination for gigs on the agenda page absurdly long

### DIFF
--- a/agenda/helpers.py
+++ b/agenda/helpers.py
@@ -37,8 +37,10 @@ from go3.colors import the_colors
 from django.shortcuts import render
 from django.core.paginator import Paginator
 
-
-PAGE_LENGTH = 10
+# This controls the pagination of gigs on the agenda page. There was strong pushback against the paging
+# mechanism, so this basically defeats it. But I still think the paginator is a good idea, and it may be worth
+# putting it back in as an option. For now, though, instead of ripping it out, it's disabled.
+PAGE_LENGTH = 10000
 
 
 @login_required

--- a/agenda/tests.py
+++ b/agenda/tests.py
@@ -28,13 +28,18 @@ class AgendaTest(GigTestBase):
         c = Client()
         c.force_login(self.joeuser)
 
-        # first 'page' of gigs should have 10
+        # first 'page' of gigs should have 19 (because pagination is very long)
         response = c.get(f'/plans/noplans/1')
-        self.assertEqual(response.content.decode('ascii').count("xyzzy"), 10)
+        self.assertEqual(response.content.decode('ascii').count("xyzzy"), 19)
 
-        # second 'page' of gigs should have 9
-        response = c.get(f'/plans/noplans/2')
-        self.assertEqual(response.content.decode('ascii').count("xyzzy"), 9)
+        # tests that pass if pagination is set to 10        
+        # # first 'page' of gigs should have 10
+        # response = c.get(f'/plans/noplans/1')
+        # self.assertEqual(response.content.decode('ascii').count("xyzzy"), 10)
+
+        # # second 'page' of gigs should have 9
+        # response = c.get(f'/plans/noplans/2')
+        # self.assertEqual(response.content.decode('ascii').count("xyzzy"), 9)
 
 
 class GridTest(GigTestBase):


### PR DESCRIPTION
There has been strong pushback against the pagination of gigs on the agenda page. I think it's worth having as an option, but for now it's disabled, practically speaking, by just making the page length very long. I think adding an option is just a matter of checking a preference and either setting the page length to 10 or whatever, or setting it very long like this does.