### PR TITLE
fixed the URL display for the public page

### DIFF
--- a/templates/band/band_detail.html
+++ b/templates/band/band_detail.html
@@ -83,7 +83,7 @@
                     <div class="row">
                         <div class="col-sm-3 col-12">{% trans "Public Profile" %}</div>
                         <div class="col-sm-9 col-12">
-                                <a href="{{url_base}}/band/{{band.condensed_name}}" target="new">{{url_base}}/band/{{ band.condensed_name }}</a>
+                                <a href="{{url_base}}/band/pub/{{band.condensed_name}}" target="new">{{url_base}}/band/pub/{{ band.condensed_name }}</a>
                         </div>
                     </div>
                     <div class="row">


### PR DESCRIPTION
The problem was just the url in the band page. Note that the url uses the "URL_BASE" defined in settings, so if you're running it on localhost you'll have to update that (or change it in the url if you're testing).