### PR TITLE
fixed order of gigs in grid

### DIFF
--- a/agenda/helpers.py
+++ b/agenda/helpers.py
@@ -175,7 +175,7 @@ def grid_gigs(request, *args, **kw):
         band=band_id,
         trashed_date__isnull=True,
         hide_from_calendar=False,
-        )
+        ).order_by('date')
 
     data = []
     for g in gigs:


### PR DESCRIPTION
Orders the gigs in the grid-o-gigs by date. Fixes #329.