### PR TITLE
Hide bands from agenda

### DIFF
--- a/agenda/tests.py
+++ b/agenda/tests.py
@@ -94,6 +94,24 @@ class AgendaTest(GigTestBase):
         response = c.get(f'/plans/noplans/1')
         self.assertEqual(response.content.decode('ascii').count("Canceled Gig-xyzzy"), 0)
 
+    def test_hide_band_from_calendar_preference(self):
+        a = self.assoc_user(self.joeuser)
+        a.hide_from_schedule = False
+        a.save()
+        self.create_gig_form(contact=self.joeuser, title=f"xyzzy")
+
+        c = Client()
+        c.force_login(self.joeuser)
+        # first 'page' of gigs should show the gig
+        response = c.get(f'/plans/noplans/1')
+        self.assertEqual(response.content.decode('ascii').count("xyzzy"), 1)
+
+        a.hide_from_schedule = True
+        a.save()
+        # first 'page' of gigs should not show the gig
+        response = c.get(f'/plans/noplans/1')
+        self.assertEqual(response.content.decode('ascii').count("xyzzy"), 0)
+
 
 class CalendarTest(GigTestBase):
     def test_calendar(self):

--- a/member/models.py
+++ b/member/models.py
@@ -121,14 +121,18 @@ class Member(AbstractUser):
 
     @property
     def future_plans(self):
+        """ used by the agenda page to decide what gigs to show """
         plans = Plan.member_plans.future_plans(self).exclude(status=PlanStatusChoices.NO_PLAN)
+        plans = plans.exclude(assoc__hide_from_schedule=True)
         if self.preferences.hide_canceled_gigs: # pylint: disable=no-member
             plans = plans.exclude(gig__status=GigStatusChoices.CANCELED)
         return plans
 
     @property
     def future_noplans(self):
+        """ used by the agenda page to decide what gigs to show """
         plans = Plan.member_plans.future_plans(self).filter(status=PlanStatusChoices.NO_PLAN)
+        plans = plans.exclude(assoc__hide_from_schedule=True)
         plans = plans.exclude(Q(assoc__is_occasional=True) & Q(gig__invite_occasionals=False))
         if self.preferences.hide_canceled_gigs: # pylint: disable=no-member
             plans = plans.exclude(gig__status=GigStatusChoices.CANCELED)


### PR DESCRIPTION
addresses #341 

Added a filter so bands that are marked "hide from calendar" do not show up on the agenda page - same as Go2 behavior.