### PR TITLE
Lowercase emails

### DIFF
--- a/go3/backends.py
+++ b/go3/backends.py
@@ -1,0 +1,30 @@
+"""
+    This file is part of Gig-o-Matic
+
+    Gig-o-Matic is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth import get_user_model
+
+class CaseInsensitiveEmailBackend(ModelBackend):
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        UserModel = get_user_model()
+        try:
+            user = UserModel.objects.get(email__iexact=username)
+        except UserModel.DoesNotExist:
+            return None
+        else:
+            if user.check_password(password):
+                return user
+        return None

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -38,12 +38,12 @@ from multiprocessing import set_start_method  # for task q
 env = environ.Env(DEBUG=bool, SENDGRID_SANDBOX_MODE_IN_DEBUG=bool, CAPTCHA_THRESHOLD=float, 
                   CALFEED_DYNAMIC_CALFEED=bool, CACHE_USE_FILEBASED=bool, ALLOWED_HOSTS=list,
                   ROUTINE_TASK_KEY=int, SENDGRID_SENDER=str, SENTRY_DSN=str, DATABASE_URL=str,
-                  LOG_LEVEL=str, EMAIL_ENABLE=bool)
+                  LOG_LEVEL=str, EMAIL_ENABLE=bool,CAPTCHA_ENABLE=bool)
 
 # reading .env file
 environ.Env.read_env()
 
-_testing = False
+_testing = env("TESTING", default=False)
 if len(sys.argv) > 1 and sys.argv[1] == "test":
     _testing = True
     logging.disable(logging.CRITICAL)

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -162,6 +162,14 @@ else:
 
 AUTH_USER_MODEL = "member.Member"
 
+# Password matching with case insensitive
+# https://pythonhint.com/post/2149716530424105/removing-case-sensitivity-from-email-in-django-login-form
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',
+    'go3.backends.CaseInsensitiveEmailBackend',
+]
+
+
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators
 

--- a/lib/captcha.py
+++ b/lib/captcha.py
@@ -26,6 +26,9 @@ def get_captcha_site_key():
 
 def verify_captcha(request):
 
+    if not env('CAPTCHA_ENABLE',default=True):
+        return True
+
     captcha_token = request.POST.get('g-recaptcha-response','')
     
     if captcha_token:

--- a/lib/email.py
+++ b/lib/email.py
@@ -28,6 +28,7 @@ def log_messages(messages):
     """ if emailing is disabled, just log the messages """
     for m in messages:
         logging.info(f"to: {m.to}  subject: {m.subject}")
+        logging.info(f"{m.body}\n")
 
 @dataclass
 class EmailRecipient:

--- a/member/models.py
+++ b/member/models.py
@@ -177,6 +177,12 @@ class Member(AbstractUser):
         return EmailRecipient(name=self.username, email=self.email,
                               language=self.preferences.language) # pylint: disable=no-member
 
+    def save(self, *args, **kwargs):
+        """ when creating members with a form, the usermanager isn't used so we have to override save """
+        self.email = self.email.lower()
+        # then super
+        super().save(*args, **kwargs)
+
     def delete(self, *args, **kwargs):
         """ when we get deleted, remove plans for future gigs and set us to deleted """
         Plan.member_plans.future_plans(self).filter(gig__is_archived=False).delete()

--- a/member/models.py
+++ b/member/models.py
@@ -253,4 +253,4 @@ class EmailConfirmation(models.Model):
     language = models.CharField(choices=LANGUAGES, max_length=200, default='en-US')
 
     def as_email_recipient(self):
-        return EmailRecipient(email=self.member.email, language=self.language)
+        return EmailRecipient(email=self.new_email, language=self.language)

--- a/member/models.py
+++ b/member/models.py
@@ -40,7 +40,7 @@ class MemberManager(BaseUserManager):
         """
         if not email:
             raise ValueError('The given email must be set')
-        email = self.normalize_email(email)
+        email = self.normalize_email(email).lower()
         user = self.model(email=email, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)

--- a/member/tests.py
+++ b/member/tests.py
@@ -56,6 +56,11 @@ class MemberTest(TestCase):
         Band.objects.all().delete()
         Assoc.objects.all().delete()
 
+    def test_member_email(self):
+        m = Member.objects.create_user('tEsTmEmBeR@FoO.CoM', password='abc')
+        self.assertEqual(m.email,"testmember@foo.com")
+
+
     def test_member_bands(self):
         """ test some basics of member creation """
         m = Member.objects.all()

--- a/member/tests.py
+++ b/member/tests.py
@@ -59,6 +59,9 @@ class MemberTest(TestCase):
     def test_member_email(self):
         m = Member.objects.create_user('tEsTmEmBeR@FoO.CoM', password='abc')
         self.assertEqual(m.email,"testmember@foo.com")
+        m.email = "TESTING@TEST.COM"
+        m.save()
+        self.assertEqual(m.email,"testing@test.com")
 
 
     def test_member_bands(self):

--- a/member/views.py
+++ b/member/views.py
@@ -235,6 +235,8 @@ class InviteView(LoginRequiredMixin, FormView):
 
         invited, in_band, invalid = [], [], []
         for email in emails:
+            email=email.lower()
+            
             try:
                 validate_email(email)
             except ValidationError:

--- a/templates/member/signup.html
+++ b/templates/member/signup.html
@@ -20,8 +20,14 @@
             <a class="btn btn-secondary" href="/">{% trans "Cancel" %}</a>
         </div>
         <div>
-            <button type="submit" class="btn btn-primary g-recaptcha" data-sitekey="{{ site_key }}" data-callback='onSubmit' 
-            data-action='submit'>{% trans 'Sign me up!' %}</button>
+            <button type="submit" 
+                {% if enable_captcha %}
+                    class="btn btn-primary g-recaptcha" 
+                {% else %}
+                    class="btn btn-primary"
+                {% endif %}
+                    data-sitekey="{{ site_key }}" data-callback='onSubmit' 
+                data-action='submit'>{% trans 'Sign me up!' %}</button>
         </div>
     </div>
 </form>


### PR DESCRIPTION
Added various bits so emails are properly lowercased:
- when creating a member object (using either the membermanager or when saving a member object)
- when inviting members
- added login authentication bit to compare to database without case sensitivity
- added a test case or two

Also
- fixed bug in email-address change process so confirmation goes to new address, not old

Plus
- added some helpful debugging things: ability to disable captcha from settings, printing out email body when email is disabled