### PR TITLE
fixed problem with admin members

### DIFF
--- a/gig/views.py
+++ b/gig/views.py
@@ -52,7 +52,7 @@ class DetailView(LoginRequiredMixin, UserPassesTestMixin, generic.DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['user_has_band_admin'] = has_band_admin(
+        context['the_user_is_band_admin'] = has_band_admin(
             self.request.user, self.object.band)
         context['user_has_manage_gig_permission'] = has_manage_gig_permission(
             self.request.user, self.object.band)

--- a/templates/gig/gig_plan_edit.html
+++ b/templates/gig/gig_plan_edit.html
@@ -52,7 +52,7 @@
         {% endif %}
     </div>
     {% if plan.gig.is_archived == False %}
-        {% if plan_member == user or user_has_band_admin %}
+        {% if plan_member == user or the_user_is_band_admin %}
             <div class="col-8 btn-group" role="group" style="display:flex; align-items:center;" >
                 {% include "gig/plan_icon_button.html" with simple_planning=band.simple_planning %}
                 {% if band.plan_feedback %}


### PR DESCRIPTION
Fixes a problem noted by a new user that band admins didn't seem to have all the features - turns out the admin privileges were passed to templates with the wrong name. Now fixed.