### PR TITLE
Show images on public page

### DIFF
--- a/band/views.py
+++ b/band/views.py
@@ -80,8 +80,8 @@ class DetailView(generic.DetailView):
                         links.append([parts[0],':'.join(parts[1:])])
                 context['the_member_links'] = links
 
-            if the_band.images:
-                context['the_images'] = [l.strip() for l in the_band.images.split('\n')]
+        if the_band.images:
+            context['the_images'] = [l.strip() for l in the_band.images.split('\n')]
 
         return context
 

--- a/templates/band/band_form.html
+++ b/templates/band/band_form.html
@@ -78,6 +78,8 @@
                     </div>
                 </div>
             </div>
+            {% comment %}
+            <!-- this was from when the "band navigator" showed thumbnails -->
             <div class='row'>
                 <div class="mx-auto col-lg-8 col-md-10 col-12">
                     <div class="form-group">
@@ -88,6 +90,7 @@
                     </div>
                 </div>
             </div>
+            {% endcomment %}
             <div class='row'>
                 <div class="mx-auto col-lg-8 col-md-10 col-12">
                     <div class="form-group">


### PR DESCRIPTION
The band images should show on the band page when accessed by "the public" - that is, when not logged in and using the public-facing link. Fixed!