### PR TITLE
Fix hamburger menu on mobile

### DIFF
--- a/static/css/gigo.css
+++ b/static/css/gigo.css
@@ -123,10 +123,6 @@ a {
   background-color: #800000;
 }
 
-.navbar a {
-  color: #fff;
-}
-
 .navbar a.dropdown-item {
   color: #000;
 }

--- a/templates/base/navbar.html
+++ b/templates/base/navbar.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<nav class="navbar {% if DEBUG %} dev {% endif %} navbar-expand-md sticky-top" role="navigation">
+<nav class="navbar navbar-dark {% if DEBUG %} dev {% endif %} navbar-expand-md sticky-top" role="navigation">
   <a class="navbar-brand" href="/">Gig-<i class="far fa-heart"></i>-Matic</i></a>
 {% if user %}
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
`navbar-dark` style is needed to make hamburger menu icon show up