### PR TITLE
changed content type for calfeed to text/calendar

### DIFF
--- a/member/helpers.py
+++ b/member/helpers.py
@@ -147,7 +147,7 @@ def calfeed(request, pk):
         hr.status_code = 404
         return hr
 
-    return HttpResponse(tf)
+    return HttpResponse(tf,content_type='text/calendar')
 
 
 # helpers to define member permissions for various things


### PR DESCRIPTION
@bklang The ical validator think the content was OK but when pulling from URL it complained about the content-type. This will make it happy - any reason not to?