### PR TITLE
Make calendar date params more intuitive

### DIFF
--- a/agenda/views.py
+++ b/agenda/views.py
@@ -62,8 +62,8 @@ class CalendarView(AgendaBaseView):
         y = self.request.GET.get('y', None)
 
         if m and y:
-            m = int(m)+1
-            y = int(y)+1900
+            m = int(m)
+            y = int(y)
             context['initialDate'] = f'{y}-{m:02d}-01'
 
         return context

--- a/templates/agenda/calendar.html
+++ b/templates/agenda/calendar.html
@@ -51,10 +51,13 @@
 
     var calendar=null;
 
+    // Updates the browser address bar to reflect the current date view
     function calCallback(rawEvents, xhr) {
-        // Updates the browser address bar to reflect the current date view
-        mo = calendar.getDate();
-        window.history.replaceState({}, "", window.location.origin+window.location.pathname+"?y="+mo.getYear()+"&m="+mo.getMonth());
+        // The initial date is interpreted as UTC, so reference that timezone
+        // when determining the currentStart for the calendar in view
+        year = calendar.view.currentStart.getUTCFullYear()
+        month = calendar.view.currentStart.getUTCMonth() + 1 // Javascript zero-indexes months
+        window.history.replaceState({}, "", window.location.origin+window.location.pathname+"?y="+year+"&m="+month);
     }
 
     $(document).ready(function() {


### PR DESCRIPTION
Makes the URL for viewing the March 2024 calendar look like this: `http://localhost:8000/calendar?y=2024&m=3`
instead of this: `http://localhost:8000/calendar?y=124&m=2`