### PR TITLE
Fix dupes

### DIFF
--- a/gig/views.py
+++ b/gig/views.py
@@ -115,6 +115,13 @@ class CreateView(LoginRequiredMixin, UserPassesTestMixin, generic.CreateView):
 
     def get_form_kwargs(self, *args, **kwargs):
         kwargs = super(CreateView, self).get_form_kwargs(*args, **kwargs)
+
+        # we need to do this because there are some form fields that do not exist in the object,
+        # so we need all of the initial values from the object so we can get at them
+        # from the template.
+        if (self.object):
+            kwargs['initial'] = forms.models.model_to_dict(self.object)
+
         kwargs['band'] = self.get_band_from_kwargs(**kwargs)
         kwargs['user'] = self.request.user
         return kwargs
@@ -150,6 +157,15 @@ class UpdateView(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
         context['timezone'] = self.object.band.timezone
         return context
 
+    def get_form_kwargs(self, *args, **kwargs):
+        kwargs = super().get_form_kwargs(*args, **kwargs)
+
+        # we need to do this because there are some form fields that do not exist in the object,
+        # so we need all of the initial values from the object so we can get at them
+        # from the template.
+        kwargs['initial'] = forms.models.model_to_dict(self.object)
+        return kwargs
+
     def get_success_url(self):
         return reverse('gig-detail', kwargs={'pk': self.object.id})
 
@@ -183,8 +199,7 @@ class DuplicateView(CreateView):
         self.kwargs['bk'] = gig_orig.band.id
 
         # populate the initial data from the original gig
-        kwargs['initial'] = forms.models.model_to_dict(gig_orig,
-                                                       exclude=['calldate', 'setdate', 'enddate'])
+        kwargs['initial'] = forms.models.model_to_dict(gig_orig)
         # ...but replace the title with a 'copy of'
         kwargs['initial']['title'] = f'Copy of {kwargs["initial"]["title"]}'
         return kwargs

--- a/gig/views.py
+++ b/gig/views.py
@@ -164,6 +164,13 @@ class UpdateView(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
         # so we need all of the initial values from the object so we can get at them
         # from the template.
         kwargs['initial'] = forms.models.model_to_dict(self.object)
+        
+        # if this is not a full day event, or the date and enddate are the same,
+        # make the enddate widget on the form blank
+        if not self.object.is_full_day or \
+            self.object.enddate and self.object.date.date() == self.object.enddate.date():
+            kwargs['initial']['enddate'] = None
+        
         return kwargs
 
     def get_success_url(self):

--- a/templates/gig/gig_detail.html
+++ b/templates/gig/gig_detail.html
@@ -80,7 +80,7 @@
                 <div class="row">
                     <div class="col-2"><i class="fas fa-calendar"></i></div>
                     <div class="col-10">{{ gig.date|naturalday:"SHORT_DATE_FORMAT"|capfirst }}
-                        {% if full_day_gig %}
+                        {% if full_day_gig and gig.enddate and gig.enddate.date != gig.date.date %}
                             - {{ gig.enddate|naturalday:"SHORT_DATE_FORMAT"|capfirst }}
                         {% endif %}
                     </div>

--- a/templates/gig/gig_form.html
+++ b/templates/gig/gig_form.html
@@ -62,7 +62,7 @@
                     {{ form.call_date.label_tag }}
                     {{ form.call_date.errors }}
                 </div>
-                <div class="col-4 enddate{% if not object.is_full_day %} style="display:none;{% endif %}">
+                <div class="col-4 enddate{% if not form.initial.is_full_day %} style="display:none;{% endif %}">
                     {{ form.end_date.label_tag }}
                     {{ form.end_date.errors }}                    
                 </div>
@@ -83,7 +83,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="form-group col-4 enddate{% if not object.is_full_day %} style="display:none;{% endif %}">
+                <div class="form-group col-4 enddate{% if not form.initial.is_full_day %} style="display:none;{% endif %}">
                     <div class="form-group">
                         <div class="input-group date" id="id_end_date_widget" data-target-input="nearest">
                             <input type="text" name="end_date" class="form-control datetimepicker-input" id="id_end_date" data-target="#id_end_date_widget"/>
@@ -95,7 +95,7 @@
                 </div>
             </div>
 
-            <div class="row gigtimes{% if object.is_full_day %} style="display:none;{% endif %}">
+            <div class="row gigtimes{% if form.initial.is_full_day %} style="display:none;{% endif %}">
                 <div class="col-4">
                     {{ form.call_time.label_tag }}
                     {{ form.call_time.errors }}
@@ -109,7 +109,7 @@
                     {{ form.end_time.errors }}
                 </div>
             </div>
-            <div class="row gigtimes{% if object.is_full_day %} style="display:none;{% endif %}">
+            <div class="row gigtimes{% if form.initial.is_full_day %} style="display:none;{% endif %}">
                 <div class="form-group col-4">
                     <div class="form-group">
                         <div class="input-group date" id="id_call_time_widget" data-target-input="nearest">
@@ -316,8 +316,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if object.date %}
-            defaultDate: '{{ object.date.isoformat }}',
+        {% if form.initial.date %}
+            defaultDate: '{{ form.initial.date.isoformat }}',
         {% endif %}
     });
     $('#id_end_date_widget').datetimepicker({
@@ -329,8 +329,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if object.enddate %}
-            defaultDate: '{{ object.enddate.isoformat }}',
+        {% if form.initial.enddate %}
+            defaultDate: '{{ form.initial.enddate.isoformat }}',
         {% endif %}
     });
     $('#id_call_time_widget').datetimepicker({
@@ -341,8 +341,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if object.date and object.has_call_time %}
-            defaultDate: '{{ object.date.isoformat }}',
+        {% if form.initial.date and form.initial.has_call_time %}
+            defaultDate: '{{ form.initial.date.isoformat }}',
         {% endif %}
     });
     $('#id_set_time_widget').datetimepicker({
@@ -353,8 +353,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if object.setdate and object.has_set_time %}
-            defaultDate: '{{ object.setdate.isoformat }}',
+        {% if form.initial.setdate and form.initial.has_set_time %}
+            defaultDate: '{{ form.initial.setdate.isoformat }}',
         {% endif %}
     });
     $('#id_end_time_widget').datetimepicker({
@@ -365,8 +365,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if object.enddate and object.has_end_time %}
-            defaultDate: '{{ object.enddate.isoformat }}',
+        {% if form.initial.enddate and form.initial.has_end_time %}
+            defaultDate: '{{ form.initial.enddate.isoformat }}',
         {% endif %}
     });
 


### PR DESCRIPTION
Fixes the problem where duplicate gigs were not getting the dates/times of the original gig. Also fixed an issue that occured when turning a gig that had times into a full-day gig - the enddate would be filled in but be the same as the startdate. For cases where we know the enddate should be blank, we now set it that way before rendering the form.