### PR TITLE
Improved calendar styles

### DIFF
--- a/agenda/helpers.py
+++ b/agenda/helpers.py
@@ -89,7 +89,7 @@ def calendar_events(request, pk):
     multiband = len(user_assocs) > 1
     for g in the_gigs:
         gig = {}
-        gig['title'] = f'{g.band.name} - {g.title}' if multiband else g.title
+        gig['title'] = f'{g.band.shortname or g.band.name}: {g.title}' if multiband else g.title
 
         enddate = g.enddate if g.enddate else g.date
         if g.is_full_day:

--- a/agenda/helpers.py
+++ b/agenda/helpers.py
@@ -96,18 +96,21 @@ def calendar_events(request, pk):
             gig['start'] = str(g.date.date())
             # Like icalendar, the end date is expected to be non-inclusive
             gig['end'] = str(enddate.date() + timedelta(days=1))
+            gig['allDay'] = True
         else:
             gig['start'] = str(g.date)
             gig['end'] = str(g.enddate)
 
         gig['url'] = f'/gig/{g.id}'
+
+        # Gig styling
+        gig['display'] = 'block'
         gig['backgroundColor'] = band_colors[g.band.id]
         if band_colors[g.band.id] == 'white' or band_colors[g.band.id] == '#ffffff':
-            # Matches the link color defined in gigo.css
-            gig['borderColor'] = '#428bca'
-            gig['textColor'] = '#428bca'
+            gig['textColor'] = '#000'
         else:
-            gig['borderColor'] = band_colors[g.band.id]
+            gig['textColor'] = '#fff'
+
         events.append(gig)
 
     return HttpResponse(json.dumps(events))

--- a/static/css/gigo.css
+++ b/static/css/gigo.css
@@ -187,6 +187,10 @@ a {
 	border: 0;
 }
 
+.fc-h-event .fc-event-time {
+  overflow: visible;
+}
+
 .fc-h-event .fc-event-main-frame {
   padding: 0 5px;
 }

--- a/static/css/gigo.css
+++ b/static/css/gigo.css
@@ -180,9 +180,19 @@ a {
     color: firebrick;
 }
 
-/* override calendar event border thickness */
-.fc-event { /* non-theme */
-	border: 2px solid;
+/*
+ FullCalendar customizations
+ ----------------------------- */
+.fc-event {
+	border: 0;
+}
+
+.fc-h-event .fc-event-main-frame {
+  padding: 0 5px;
+}
+
+.fc-daygrid-block-event:hover {
+  background-color: #ccc !important;
 }
 
 .card-header {


### PR DESCRIPTION
* More compact band name shows more gig name
* Make all calendar events render more consistently
* Shows all events as block events, not just full-day events
* Adds a hover background color
* Fix to always show gig time without truncation

<img width="1463" alt="Screenshot 2024-03-29 at 11 14 05 PM" src="https://github.com/Gig-o-Matic/GO3/assets/167131/3c36aa31-37a8-406b-aa48-9d86dfe4ca3f">
