### PR TITLE
fixes for better handling of times on the edit form

### DIFF
--- a/gig/views.py
+++ b/gig/views.py
@@ -187,9 +187,6 @@ class UpdateView(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
         # we need to do this because there are some form fields that do not exist in the object,
         # so we need all of the initial values from the object so we can get at them
         # from the template.
-        # XXX
-        # kwargs['initial'] = forms.models.model_to_dict(self.object)
- 
         return kwargs
 
     def get_success_url(self):

--- a/gig/views.py
+++ b/gig/views.py
@@ -177,7 +177,7 @@ class UpdateView(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
         context = super().get_context_data(**kwargs)
         context['timezone'] = self.object.band.timezone
 
-        SetupFormTimes(context,self.object)
+        setup_form_times(context,self.object)
 
         return context
 

--- a/gig/views.py
+++ b/gig/views.py
@@ -146,7 +146,7 @@ class CreateView(LoginRequiredMixin, UserPassesTestMixin, generic.CreateView):
         return result
 
 
-def SetupFormTimes(context,object):
+def setup_form_times(context,object):
     context['date'] = object.date
     if object.is_full_day:
         if object.enddate and object.enddate.date() != object.date.date():

--- a/gig/views.py
+++ b/gig/views.py
@@ -109,11 +109,12 @@ class CreateView(LoginRequiredMixin, UserPassesTestMixin, generic.CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['is_new'] = True
-        context['band'] = self.get_band_from_kwargs(**kwargs)
+        context['band'] = self.get_band()
         context['timezone'] = context['band'].timezone
         return context
 
-    def get_band_from_kwargs(self, **kwargs):
+    def get_band(self):
+        """ for a createview where we have a band passed into the view as a key, use it """
         return Band.objects.get(id=self.kwargs['bk'])
 
     def get_form_kwargs(self, *args, **kwargs):
@@ -125,7 +126,7 @@ class CreateView(LoginRequiredMixin, UserPassesTestMixin, generic.CreateView):
         if (self.object):
             kwargs['initial'] = forms.models.model_to_dict(self.object)
 
-        kwargs['band'] = self.get_band_from_kwargs(**kwargs)
+        kwargs['band'] = self.get_band()
         kwargs['user'] = self.request.user
         return kwargs
 
@@ -240,7 +241,9 @@ class DuplicateView(CreateView):
         kwargs['initial']['title'] = f'Copy of {kwargs["initial"]["title"]}'
         return kwargs
 
-    def get_band_from_kwargs(self, **kwargs):
+    def get_band(self):
+        """ for a duplicate where we don't have the band passed in but we have the """
+        """ original gig, return the band from it """
         return self.original_gig.band
 
 

--- a/gig/views.py
+++ b/gig/views.py
@@ -224,7 +224,7 @@ class DuplicateView(CreateView):
         self.original_gig = Gig.objects.get(id=self.kwargs['pk'])
         context = super().get_context_data(**kwargs)
 
-        SetupFormTimes(context, self.original_gig)
+        setup_form_times(context, self.original_gig)
         return context
 
     def get_form_kwargs(self, *args, **kwargs):

--- a/gig/views.py
+++ b/gig/views.py
@@ -146,6 +146,24 @@ class CreateView(LoginRequiredMixin, UserPassesTestMixin, generic.CreateView):
         return result
 
 
+def SetupFormTimes(context,object):
+    context['date'] = object.date
+    if object.is_full_day:
+        if object.enddate and object.enddate.date() != object.date.date():
+            context['enddate'] = object.enddate
+        else:
+            context['enddate'] = None
+        context['calltime'] = None
+        context['settime'] = None
+        context['endtime'] = None
+    else:
+        context['enddate'] = None
+        context['calltime'] = object.date if object.has_call_time else None
+        context['settime'] = object.setdate if object.has_set_time else None
+        context['endtime'] = object.enddate if object.has_end_time else None
+    context['is_full_day'] = object.is_full_day
+
+
 class UpdateView(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
     model = Gig
     form_class = GigForm
@@ -158,6 +176,9 @@ class UpdateView(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['timezone'] = self.object.band.timezone
+
+        SetupFormTimes(context,self.object)
+
         return context
 
     def get_form_kwargs(self, *args, **kwargs):
@@ -166,14 +187,9 @@ class UpdateView(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
         # we need to do this because there are some form fields that do not exist in the object,
         # so we need all of the initial values from the object so we can get at them
         # from the template.
-        kwargs['initial'] = forms.models.model_to_dict(self.object)
-        
-        # if this is not a full day event, or the date and enddate are the same,
-        # make the enddate widget on the form blank
-        if not self.object.is_full_day or \
-            self.object.enddate and self.object.date.date() == self.object.enddate.date():
-            kwargs['initial']['enddate'] = None
-        
+        # XXX
+        # kwargs['initial'] = forms.models.model_to_dict(self.object)
+ 
         return kwargs
 
     def get_success_url(self):
@@ -195,28 +211,40 @@ class UpdateView(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
 
 class DuplicateView(CreateView):
 
+    original_gig = None
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.original_gig = get_object_or_404(Gig, id=self.kwargs['pk'])
+
     def test_func(self):
         if not self.request.user.is_authenticated:
             return self.handle_no_permission()
         gig = get_object_or_404(Gig, id=self.kwargs['pk'])
         return gig.band.is_editor(self.request.user)
 
+    def get_context_data(self, **kwargs):
+        self.original_gig = Gig.objects.get(id=self.kwargs['pk'])
+        context = super().get_context_data(**kwargs)
+
+        SetupFormTimes(context, self.original_gig)
+        return context
+
     def get_form_kwargs(self, *args, **kwargs):
         kwargs = super().get_form_kwargs(*args, **kwargs)
-        gig_orig = Gig.objects.get(id=self.kwargs['pk'])
         # we didn't originally get a band in the request, we got a gig pk - so get the band from that
         # and stash it among the args from the request
-        self.kwargs['bk'] = gig_orig.band.id
+        self.kwargs['bk'] = self.original_gig.band.id
+
 
         # populate the initial data from the original gig
-        kwargs['initial'] = forms.models.model_to_dict(gig_orig)
+        kwargs['initial'] = forms.models.model_to_dict(self.original_gig)
         # ...but replace the title with a 'copy of'
         kwargs['initial']['title'] = f'Copy of {kwargs["initial"]["title"]}'
         return kwargs
 
     def get_band_from_kwargs(self, **kwargs):
-        # didn't have the band from the request args, so pull it from the gig
-        return get_object_or_404(Gig, id=self.kwargs['pk']).band
+        return self.original_gig.band
 
 
 class CommentsView(UserPassesTestMixin, TemplateView):

--- a/templates/gig/gig_form.html
+++ b/templates/gig/gig_form.html
@@ -62,7 +62,7 @@
                     {{ form.call_date.label_tag }}
                     {{ form.call_date.errors }}
                 </div>
-                <div class="col-4 enddate{% if not form.initial.is_full_day %} style="display:none;{% endif %}">
+                <div class="col-4 enddate{% if not is_full_day %} style="display:none;{% endif %}">
                     {{ form.end_date.label_tag }}
                     {{ form.end_date.errors }}                    
                 </div>
@@ -83,7 +83,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="form-group col-4 enddate{% if not form.initial.is_full_day %} style="display:none;{% endif %}">
+                <div class="form-group col-4 enddate{% if not is_full_day %} style="display:none;{% endif %}">
                     <div class="form-group">
                         <div class="input-group date" id="id_end_date_widget" data-target-input="nearest">
                             <input type="text" name="end_date" class="form-control datetimepicker-input" id="id_end_date" data-target="#id_end_date_widget"/>
@@ -95,7 +95,7 @@
                 </div>
             </div>
 
-            <div class="row gigtimes{% if form.initial.is_full_day %} style="display:none;{% endif %}">
+            <div class="row gigtimes{% if is_full_day %} style="display:none;{% endif %}">
                 <div class="col-4">
                     {{ form.call_time.label_tag }}
                     {{ form.call_time.errors }}
@@ -109,7 +109,7 @@
                     {{ form.end_time.errors }}
                 </div>
             </div>
-            <div class="row gigtimes{% if form.initial.is_full_day %} style="display:none;{% endif %}">
+            <div class="row gigtimes{% if is_full_day %} style="display:none;{% endif %}">
                 <div class="form-group col-4">
                     <div class="form-group">
                         <div class="input-group date" id="id_call_time_widget" data-target-input="nearest">
@@ -316,8 +316,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if form.initial.date %}
-            defaultDate: '{{ form.initial.date.isoformat }}',
+        {% if date %}
+            defaultDate: '{{ date.isoformat }}',
         {% endif %}
     });
     $('#id_end_date_widget').datetimepicker({
@@ -329,8 +329,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if form.initial.enddate %}
-            defaultDate: '{{ form.initial.enddate.isoformat }}',
+        {% if enddate %}
+            defaultDate: '{{ enddate.isoformat }}',
         {% endif %}
     });
     $('#id_call_time_widget').datetimepicker({
@@ -341,8 +341,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if form.initial.date and form.initial.has_call_time %}
-            defaultDate: '{{ form.initial.date.isoformat }}',
+        {% if calltime %}
+            defaultDate: '{{ calltime.isoformat }}',
         {% endif %}
     });
     $('#id_set_time_widget').datetimepicker({
@@ -353,8 +353,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if form.initial.setdate and form.initial.has_set_time %}
-            defaultDate: '{{ form.initial.setdate.isoformat }}',
+        {% if settime %}
+            defaultDate: '{{ settime.isoformat }}',
         {% endif %}
     });
     $('#id_end_time_widget').datetimepicker({
@@ -365,8 +365,8 @@ $(document).ready(function () {
                     down: "fa fa-arrow-down",
                 },
         locale: '{{ user.preferences.language }}',
-        {% if form.initial.enddate and form.initial.has_end_time %}
-            defaultDate: '{{ form.initial.enddate.isoformat }}',
+        {% if endtime %}
+            defaultDate: '{{ endtime.isoformat }}',
         {% endif %}
     });
 


### PR DESCRIPTION
Decouples the gig object from the rendering of the form for clearer handling of end dates and better toggling between all-day and not-all-day events.