### PR TITLE
extended maximum session time to 1 year

### DIFF
--- a/go3/settings.py
+++ b/go3/settings.py
@@ -191,6 +191,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Session timeout - default is 2 weeks but can be longer
+SESSION_COOKIE_AGE = 31536000 # one year
+
 # Increase the password reset token expiration. Default is 3 days, increase to 30
 # Since we are using this feature to onboard users, many people are not expecting
 # the email, and so not taking action fast enough. Let's give them more grace,


### PR DESCRIPTION
Django default is 2 weeks. Old gig-o never expired. Any reason not to extend to a year?