### PR TITLE
Account language

### DIFF
--- a/member/tests.py
+++ b/member/tests.py
@@ -766,7 +766,7 @@ class InviteTest(TemplateTestCase):
         self.assertTemplateUsed(response, 'member/invite_expired.html')
 
     def test_create_member(self):
-        invite = Invite.objects.create(email='new@example.com', band=self.band)
+        invite = Invite.objects.create(email='new@example.com', band=self.band, language='fr')
         response = self.client.post(reverse('member-create', args=[invite.id]),
                                     {'username': 'New',
                                      'nickname': 'new',
@@ -779,6 +779,7 @@ class InviteTest(TemplateTestCase):
         new = Member.objects.filter(email='new@example.com').get()
         self.assertEqual(new.username, 'New')
         self.assertEqual(new.nickname, 'new')
+        self.assertEqual(new.preferences.language,'en')
 
     def test_create_member_no_band(self):
         invite = Invite.objects.create(email='new@example.com', band=None)

--- a/member/tests.py
+++ b/member/tests.py
@@ -779,7 +779,7 @@ class InviteTest(TemplateTestCase):
         new = Member.objects.filter(email='new@example.com').get()
         self.assertEqual(new.username, 'New')
         self.assertEqual(new.nickname, 'new')
-        self.assertEqual(new.preferences.language,'en')
+        self.assertEqual(new.preferences.language,'fr')
 
     def test_create_member_no_band(self):
         invite = Invite.objects.create(email='new@example.com', band=None)

--- a/member/views.py
+++ b/member/views.py
@@ -36,6 +36,7 @@ from go3.settings import env
 from django.utils import translation
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import get_language_from_request
 from django.conf import settings
 from django.shortcuts import get_object_or_404, redirect, render
 from django.core.validators import validate_email
@@ -364,7 +365,7 @@ class MemberCreateView(CreateView):
         retval = super().form_valid(form)
         member = authenticate(username=self.invite.email, password=form.cleaned_data['password1'])
         member.preferences.language = self.invite.language
-        #member.preferences.save()  # Why isn't this necessary?
+        member.preferences.save()  # Why isn't this necessary?
         login(self.request, member)
         return retval
 
@@ -408,7 +409,7 @@ class SignupView(FormView):
             messages.info(self.request, format_lazy(_('An account associated with {email} already exists.  You can recover this account via the "Forgot Password?" link below.'), email=email))
             return redirect('home')
 
-        Invite.objects.create(band=None, email=email)
+        Invite.objects.create(band=None, email=email, language=get_language_from_request(self.request))
         return render(self.request, 'member/signup_pending.html', {'email': email})
 
 

--- a/member/views.py
+++ b/member/views.py
@@ -365,7 +365,7 @@ class MemberCreateView(CreateView):
         retval = super().form_valid(form)
         member = authenticate(username=self.invite.email, password=form.cleaned_data['password1'])
         member.preferences.language = self.invite.language
-        member.preferences.save()  # Why isn't this necessary?
+        #member.preferences.save()  # Why isn't this necessary?
         login(self.request, member)
         return retval
 
@@ -409,6 +409,7 @@ class SignupView(FormView):
             messages.info(self.request, format_lazy(_('An account associated with {email} already exists.  You can recover this account via the "Forgot Password?" link below.'), email=email))
             return redirect('home')
 
+        # put the language in the invitation - this will end up in the users's preferences
         Invite.objects.create(band=None, email=email, language=get_language_from_request(self.request))
         return render(self.request, 'member/signup_pending.html', {'email': email})
 


### PR DESCRIPTION
Ensures that if a user signs up after having selected a language on the signup page, that language makes its way into their preferences when they confirm their email.