### PR TITLE
activate timezone before showing schedule

### DIFF
--- a/agenda/views.py
+++ b/agenda/views.py
@@ -18,6 +18,7 @@ from django.http import HttpResponse
 from django.views.generic.base import TemplateView
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.decorators import login_required
+from django.utils import timezone
 from member.models import MemberPreferences
 from member.util import AgendaChoices
 from band.models import Assoc
@@ -49,6 +50,9 @@ class AgendaView(AgendaBaseView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        b = self.request.user.assocs.first().band
+        timezone.activate(b.timezone)
+
         return context
 
 


### PR DESCRIPTION
In the schedule page, activate the user's timezone before showing the page. This is the timezone of the band of the first "assoc" in the member's list, which is not necessarily actually the member's timezone, but for now is likely ok.

@bklang I'm going to put this through to patch the problem on the schedule page but I also notice the timezone seems wrong on the calendar gigs.