### PR TITLE
Remove member plans

### DIFF
--- a/band/helpers.py
+++ b/band/helpers.py
@@ -175,7 +175,7 @@ def do_delete_assoc(a):
 
     if a.status==AssocStatusChoices.CONFIRMED:
         # we can get rid of any future plans associated with this assoc
-        Plan.member_plans.future_plans(a.member).filter(gig__is_archived=False).delete()
+        Plan.member_plans.future_plans(a.member).filter(assoc=a, gig__is_archived=False).delete()
         a.member.cal_feed_dirty = True
 
         # and now turn this member "not confirmed" - but they're still an alum

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -113,11 +113,12 @@ class GigTestBase(TestCase):
         status = kwargs.pop("status", GigStatusChoices.UNCONFIRMED)
         contact = kwargs.pop("contact", self.joeuser).id
         send_update = kwargs.pop("send_update", True)
+        the_band = kwargs.pop("band",self.band)
 
         c = Client()
         c.force_login(user if user else self.joeuser)
         response = c.post(
-            f"/gig/create/{self.band.id}",
+            f"/gig/create/{the_band.id}",
             {
                 "title": title,
                 "is_full_day": is_full_day,


### PR DESCRIPTION
When removing a member from a band, we were deleting future plans for all bands the member belonged to, not just the one they were leaving. This fixes that.