### PR TITLE
added override for login page to set user preference language in case…

### DIFF
--- a/go3/urls.py
+++ b/go3/urls.py
@@ -41,9 +41,11 @@ from go3.schema import schema
 from agenda.views import PrivateGraphQLView
 from django.views.i18n import JavaScriptCatalog
 from member.helpers import go2_id_calfeed
+from member.views import LanguageLoginView
 
 urlpatterns = [
     path('', include('agenda.urls')),
+    path('accounts/login/', LanguageLoginView.as_view(), name='login'),
     path('accounts/', include('django.contrib.auth.urls')),
     path('i18n/', include('django.conf.urls.i18n')),
     path('band/', include('band.urls')),

--- a/member/views.py
+++ b/member/views.py
@@ -29,7 +29,7 @@ from django.views.generic.base import TemplateView
 from django.contrib.auth import login, authenticate
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin, AccessMixin
-from django.contrib.auth.views import PasswordChangeDoneView, PasswordResetView
+from django.contrib.auth.views import PasswordChangeDoneView, PasswordResetView, LoginView
 from django.contrib import messages
 from go3.colors import the_colors
 from go3.settings import env
@@ -456,3 +456,14 @@ def confirm_email(request, pk):
     return set_language(
                 render(request, 'member/email_change_confirmation.html',
                         {'validlink': valid}))
+
+
+class LanguageLoginView(LoginView):
+    """ we override the default loginview and set the user's preferential language """
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        translation.activate(self.request.user.preferences.language)
+        response.set_cookie(settings.LANGUAGE_COOKIE_NAME, self.request.user.preferences.language )
+        return response
+


### PR DESCRIPTION
… the cookie has not been set previously. This can happen if I set my language to something and then switch to another computer, say. If you're preference is to use the UK date format so you set your langauge to English(UK) but then switch to another browser, you will be looking at English(US) by default and not realize it.

The change made here just forces the language cookie to be replaced when you log in.