### PR TITLE
Public calfeed times

### DIFF
--- a/band/helpers.py
+++ b/band/helpers.py
@@ -264,7 +264,7 @@ def prepare_band_calfeed(band):
     }
 
     the_gigs = Gig.objects.filter(**filter_args)
-    cf = make_calfeed(band, the_gigs, band.default_language, band.pub_cal_feed_id)
+    cf = make_calfeed(band, the_gigs, band.default_language, band.pub_cal_feed_id,is_for_band=True)
     return cf
 
 

--- a/lib/caldav.py
+++ b/lib/caldav.py
@@ -51,7 +51,7 @@ def delete_calfeed(tag):
             default_storage.delete(file_path)
 
 
-def make_calfeed(the_title, the_events, the_language, the_uid):
+def make_calfeed(the_title, the_events, the_language, the_uid, is_for_band=False):
     """ construct an ical-compliant stream from a list of events """
 
     def _make_summary(event):
@@ -89,7 +89,7 @@ def make_calfeed(the_title, the_events, the_language, the_uid):
                     enddate = (e.enddate if e.enddate else e.date).date() + timedelta(days=1)
                     event.add('dtend', enddate, {'value': 'DATE'})
                 else:
-                    event.add('dtstart', e.date)
+                    event.add('dtstart', e.setdate if (is_for_band and e.setdate) else e.date)
                     event.add(
                         'dtend', e.enddate if e.enddate else e.date + timedelta(hours=1))
                 event.add('description', _make_description(e))

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -95,11 +95,19 @@ class CaldavTest(TestCase):
 
     def test_calfeed_event_start(self):
         # for member feeds, the start date should be the call time; for band feeds, the start should be the set time
+
+        # first, a gig without a set time should show the call time
+        cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, 
+                          self.band.pub_cal_feed_id, is_for_band=True)
+        self.assertTrue(cf.find(b'DTSTART:20200229T143000Z')>0)
+
+        # for member feeds, should show the call time
         self.testgig.setdate = self.testgig.date + timedelta(hours=1)
         self.testgig.save()
         cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, self.joeuser.cal_feed_id)
         self.assertTrue(cf.find(b'DTSTART:20200229T143000Z')>0)
 
+        # for band feeds, should show the set time
         cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, 
                           self.band.pub_cal_feed_id, is_for_band=True)
         self.assertTrue(cf.find(b'DTSTART:20200229T143000Z')==-1)

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -93,6 +93,19 @@ class CaldavTest(TestCase):
         self.assertTrue(cf.find(b'DTSTART:20200229T143000Z')>0)
         self.assertTrue(cf.find(b'DTEND:20200229T163000Z')>0)
 
+    def test_calfeed_event_start(self):
+        # for member feeds, the start date should be the call time; for band feeds, the start should be the set time
+        self.testgig.setdate = self.testgig.date + timedelta(hours=1)
+        self.testgig.save()
+        cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, self.joeuser.cal_feed_id)
+        self.assertTrue(cf.find(b'DTSTART:20200229T143000Z')>0)
+
+        cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, 
+                          self.band.pub_cal_feed_id, is_for_band=True)
+        self.assertTrue(cf.find(b'DTSTART:20200229T143000Z')==-1)
+        self.assertTrue(cf.find(b'DTSTART:20200229T153000Z')>0)
+
+
     def test_calfeed_event_full_day(self):
         self.testgig.is_full_day = True
         self.testgig.save()


### PR DESCRIPTION
For gigs with a set time, the band public calfeed should show the set time instead of the call time.