### PR TITLE
Add Address to Gig Notification email

### DIFF
--- a/gig/helpers.py
+++ b/gig/helpers.py
@@ -140,6 +140,9 @@ def generate_changes(latest, previous):
 
     if 'details' in diff.changed_fields:
         changes.append((_('Details'), _('(See below.)'), None))
+
+    if 'setlist' in diff.changed_fields:
+        changes.append((_('Set List'), None, None))
     
     if 'dress' in diff.changed_fields:
         changes.append((_('What To Wear'), _('(See below.)'), None))

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -674,6 +674,31 @@ class GigTest(GigTestBase):
         self.assertIn(self.janeuser.display_name, message.body)
         self.assertIn(f"(was {self.joeuser.display_name})", message.body)
 
+    def test_gig_edit_setlist(self):
+        g, _, _ = self.assoc_joe_and_create_gig()
+        self.update_gig_form(g)
+
+        mail.outbox = []
+        self.update_gig_form(
+            g, setlist="Tequila\nLand of a Thousand Dances"
+        )
+
+        message = mail.outbox[0]
+        self.assertIn("(Set List)", message.subject)
+
+    def test_gig_edit_address(self):
+        g, _, _ = self.assoc_joe_and_create_gig()
+        self.update_gig_form(g)
+
+        mail.outbox = []
+        self.update_gig_form(
+            g, address="123 Main St. Anytown, MN 55016"
+        )
+
+        message = mail.outbox[0]
+        self.assertIn("(Address)", message.subject)
+        self.assertIn("Address: 123 Main St. Anytown, MN 55016", message.body)
+
     def test_gig_edit_trans(self):
         self.joeuser.preferences.language = "de"
         self.joeuser.save()

--- a/templates/email/gig.md
+++ b/templates/email/gig.md
@@ -15,6 +15,10 @@ Subject: {% block subject %}{% endblock %}
 {% trans "End Time" %}: {{ gig.enddate|date:"TIME_FORMAT" }}{% endif %}
 {% endif %}{% if gig.datenotes %}{% trans "Notes" %}: {{ gig.datenotes }}{% endif %}{% endblock gigdates %}
 
+{% if gig.address %}
+{% trans "Address" %}: {{ gig.address }}
+{% endif %}
+
 {% trans "Contact" %}: {{ contact_name }}
 {% trans "Status" %}: {{ gig.status_string }}
 {% if gig.details %}


### PR DESCRIPTION
As requested by a few people.

Also detects whether the set list has changed and includes that in the subject line if so. This should avoid some empty change lists in email subjects.