### PR TITLE
Fix public view

### DIFF
--- a/band/tests.py
+++ b/band/tests.py
@@ -625,11 +625,18 @@ class PublicBandPageTest(GigTestBase):
         """ the public page should be accessible to everyone. The band detail """
         """ page should only be accessible to members """
 
-        self.assoc_joe_and_create_gig()
+        _, a, _ = self.assoc_joe_and_create_gig()
         self.client.force_login(self.joeuser)
+
         resp = self.client.get(
             reverse('band-detail', args=[self.band.id]))
         self.assertEqual(resp.status_code, 200)
+
+        a.status = AssocStatusChoices.NOT_CONFIRMED
+        a.save()
+        resp = self.client.get(
+            reverse('band-detail', args=[self.band.id]))
+        self.assertEqual(resp.status_code, 403)
 
         otherband = Band.objects.create(name='other band', shortname="ob")
         resp = self.client.get(

--- a/band/urls.py
+++ b/band/urls.py
@@ -35,7 +35,7 @@ urlpatterns = [
     path('<int:pk>/set_sections', helpers.set_sections, name='band-set-sections'), 
     path('<int:pk>/public_gigs', helpers.public_gigs, name='band-public-gigs'), 
 
-    path('pub/<str:name>/', helpers.band_public_page, name='band-public-page'),
+    path('pub/<str:name>/', views.PublicDetailView.as_view(), name='band-public-page'),
 
     path('assoc/<int:ak>/tfparam', helpers.set_assoc_tfparam, name='assoc-tfparam'),
     path('assoc/<int:ak>/color/<int:colorindex>', helpers.set_assoc_color, name='assoc-color'),

--- a/band/views.py
+++ b/band/views.py
@@ -53,14 +53,10 @@ class DetailView(LoginRequiredMixin, generic.DetailView):
 
         context['url_base'] = URL_BASE
 
-        is_associated = True
-        if the_user.is_anonymous:
+        try:
+            assoc = Assoc.objects.get(band=the_band, member=the_user)
+        except Assoc.DoesNotExist:
             assoc = None
-        else:
-            try:
-                assoc = Assoc.objects.get(band=the_band, member=the_user)
-            except Assoc.DoesNotExist:
-                assoc = None
             
         is_associated = assoc is not None and assoc.status == AssocStatusChoices.CONFIRMED
         context['the_user_is_associated'] = is_associated
@@ -92,21 +88,15 @@ class DetailView(LoginRequiredMixin, generic.DetailView):
     #     return reverse('member-detail', kwargs={'pk': self.object.id})
 
 
-class PublicDetailView(generic.DetailView):
-    model = Band
-
-    def get_object(self):
-        try:
-            return Band.objects.get(condensed_name=self.kwargs['name'])
-        except:
-            return redirect('/')
+class PublicDetailView(TemplateView):
+    template_name = 'band/band_public.html'
 
     def get_context_data(self, **kwargs):
+        the_band = get_object_or_404(Band, condensed_name=self.kwargs['name'])
         
-        the_band = self.object
-
         context = super().get_context_data(**kwargs)
 
+        context['band'] = the_band
         context['url_base'] = URL_BASE            
         context['the_user_is_associated'] = False
 

--- a/band/views.py
+++ b/band/views.py
@@ -91,7 +91,7 @@ class PublicDetailView(TemplateView):
     template_name = 'band/band_public.html'
 
     def get_context_data(self, **kwargs):
-        the_band = get_object_or_404(Band, condensed_name=self.kwargs['name'])
+        the_band = get_object_or_404(Band, shortname=self.kwargs['name'])
         
         context = super().get_context_data(**kwargs)
 

--- a/band/views.py
+++ b/band/views.py
@@ -45,9 +45,11 @@ class DetailView(LoginRequiredMixin, UserPassesTestMixin, generic.DetailView):
     model = Band
 
     def test_func(self):
+        if self.request.user.is_superuser:
+            return True
         # if we're not active in the band, deny entry!
         assoc = Assoc.objects.filter(band=self.kwargs['pk'], member=self.request.user).first()
-        return assoc and (self.request.user.is_superuser or assoc.status==AssocStatusChoices.CONFIRMED)
+        return assoc and assoc.status==AssocStatusChoices.CONFIRMED
                 
     def get_context_data(self, **kwargs):
         the_band = self.object
@@ -57,10 +59,8 @@ class DetailView(LoginRequiredMixin, UserPassesTestMixin, generic.DetailView):
 
         context['url_base'] = URL_BASE
 
-        assoc = Assoc.objects.get(band=the_band, member=the_user)
+        assoc = None if the_user.is_superuser else Assoc.objects.get(band=the_band, member=the_user)
             
-        is_associated = assoc is not None and assoc.status == AssocStatusChoices.CONFIRMED
-
         context['the_user_is_band_admin'] = the_user.is_superuser or (assoc and assoc.is_admin)
 
         context['the_pending_members'] = Assoc.objects.filter(band=the_band, status=AssocStatusChoices.PENDING)

--- a/templates/band/band_detail.html
+++ b/templates/band/band_detail.html
@@ -15,7 +15,7 @@
 
         <div class="page-header">
             {{ band.name }}
-            {% if the_user_is_associated and band.shortname %}
+            {% if band.shortname %}
                 <br>
                 ({% trans "a.k.a." %}&nbsp;{{ band.shortname }})
             {% endif %}
@@ -60,44 +60,42 @@
                         </div>
                     </div>
                 {% endif %}
-                {% if the_user_is_associated or request.user.is_superuser %}
-                    <div class="row mt-4">
-                        <div class="col-sm-3 col-12">{% trans "Resources" %}</div>
-                        <div class="col-sm-9 col-12">
-                                {% if the_member_links %}
-                                    {% for l in the_member_links %}
-                                        <a href="{{l.1}}" target="_new">{{ l.0 }}</a><br>
-                                    {% endfor %}
-                                {% endif %}
-                                <a href="{% url 'band-archive' pk=band.id %}">{% trans "Gig Archive" %}</a><br>
-                                {% if request.user.is_superuser or the_user_is_band_admin %}
-                                    <a href="{% url 'band-trashcan' pk=band.id %}">{% trans "Gig Trashcan" %}</a><br>
-                                {% endif %}
-                        </div>
+                <div class="row mt-4">
+                    <div class="col-sm-3 col-12">{% trans "Resources" %}</div>
+                    <div class="col-sm-9 col-12">
+                            {% if the_member_links %}
+                                {% for l in the_member_links %}
+                                    <a href="{{l.1}}" target="_new">{{ l.0 }}</a><br>
+                                {% endfor %}
+                            {% endif %}
+                            <a href="{% url 'band-archive' pk=band.id %}">{% trans "Gig Archive" %}</a><br>
+                            {% if request.user.is_superuser or the_user_is_band_admin %}
+                                <a href="{% url 'band-trashcan' pk=band.id %}">{% trans "Gig Trashcan" %}</a><br>
+                            {% endif %}
                     </div>
-                    <div class="row">
-                        <div class="col-12">
-                            &nbsp;
-                        </div>
+                </div>
+                <div class="row">
+                    <div class="col-12">
+                        &nbsp;
                     </div>
-                    <div class="row">
-                        <div class="col-sm-3 col-12">{% trans "Public Profile" %}</div>
-                        <div class="col-sm-9 col-12">
-                                <a href="{{url_base}}/band/pub/{{band.condensed_name}}" target="new">{{url_base}}/band/pub/{{ band.condensed_name }}</a>
-                        </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-3 col-12">{% trans "Public Profile" %}</div>
+                    <div class="col-sm-9 col-12">
+                            <a href="{{url_base}}/band/pub/{{band.condensed_name}}" target="new">{{url_base}}/band/pub/{{ band.condensed_name }}</a>
                     </div>
-                    <div class="row">
-                        <div class="col-12">
-                            &nbsp;
-                        </div>
+                </div>
+                <div class="row">
+                    <div class="col-12">
+                        &nbsp;
                     </div>
-                    <div class="row">
-                        <div class="col-sm-3 col-12">{% trans "Public Gig Calendar Feed" %}</div>
-                        <div class="col-sm-9 col-12">
-                                <a href="{% url 'band-calfeed' pk=band.pub_cal_feed_id %}" onclick="return false;">{% trans "Subscribe using this link's URL" %}</a>
-                        </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-3 col-12">{% trans "Public Gig Calendar Feed" %}</div>
+                    <div class="col-sm-9 col-12">
+                            <a href="{% url 'band-calfeed' pk=band.pub_cal_feed_id %}" onclick="return false;">{% trans "Subscribe using this link's URL" %}</a>
                     </div>
-                {% endif %}
+                </div>
             </div> <!-- card-body -->
         </div> <!-- card -->
 
@@ -133,198 +131,163 @@
             </div>
         {% endif %}
 
-        {% if the_user_is_associated is False and request.user.is_superuser is False %}
-        {% if band.share_gigs %}
+        {% if the_user_is_band_admin and the_pending_members %}
             <div class="card mt-4">
                 <div class="card-header">
-                    <div class="row titlerow">
-                        <div class="col-12">
-                            {% trans "Upcoming Gigs" %}
-                        </div>
-                    </div>
-                </div>
-                <div class="card-body" id="upcoming-gigs" hx-get="{% url 'band-public-gigs' pk=band.id %}" hx-trigger="load">
-                    <div class="row">
-                        <i class="fas fa-spinner fa-pulse fa-lg"></i>
-                    </div>
-                </div>
-            </div>
-        {% endif %}
-        {% comment %}
-            {% if the_user %}
-                <div class="card mt-4">
-                    <div class="card-header">
-                        <div class="row titlerow"><div class="col-12">
-                            {% trans "Members With Public Profiles" %}
-                        </div></div>
-                    </div>
-                    <div class="card-body" id="public-members">
-                        <i class="fas fa-spinner fa-pulse fa-lg"></i>
-                    </div>
-                </div>
-            {% endif %}
-        {% endcomment %}
-        {% elif the_user in the_pending_members and request.user.is_superuser == False %}
-            {% trans "Your membership is pending - ask a band member to confirm you!" %}
-        {% else %}
-            {% if the_user_is_band_admin and the_pending_members %}
-                <div class="card mt-4">
-                    <div class="card-header">
-                        <div class="row titlerow" id="pending-members"><div class="col-12">
-                            {% trans "Pending Members" %} <span class="badge badge-pill badge-secondary">{{the_pending_members.all|length}}</span>
-                        </div></div>
-                    </div>
-                    <div class="card-body">
-                        {% for assoc in the_pending_members %}
-                        <div class="row" style="padding-top: 5px; padding-bottom: 5px; {% cycle '' 'background:#f5f5f5;' %}">
-                            <div class="col-md-2 col-sm-2 col-12">
-                                <a href="{% url 'member-detail' pk=assoc.member.id %}">{{ assoc.member.display_name|escape }}</a>
-                            </div>
-                            <div class="col-md-4 col-sm-4 col-12">
-                                {{ assoc.member.email|escape }}
-                            </div>
-                            <div class="col-md-6 col-sm-6 col-12">
-                                <button class="btn btn-primary btn-sm"
-                                   hx-ext="reload-page"
-                                   hx-post="{% url 'assoc-confirm' ak=assoc.id %}"
-                                   hx-swap="none">
-                                    {% trans "yes, confirm member!" %}
-                                    <span class="htmx-indicator">
-                                        <i class="fa fa-spinner fa-spin fa-lg"></i>
-                                    </span>    
-                                </button>
-                                <button class="btn btn-secondary btn-sm"
-                                   hx-ext="reload-page"
-                                   hx-post="{% url 'assoc-delete' ak=assoc.id %}"
-                                   hx-swap="none">
-                                    {% trans "no, reject!" %}
-                                    <span class="htmx-indicator">
-                                        <i class="fa fa-spinner fa-spin fa-lg"></i>
-                                    </span>    
-                                </button>
-                            </div>
-                        </div>
-                        {% endfor %}
-                    </div>
-                </div> <!-- panel -->
-            {% endif %}
-
-            {% if the_user_is_band_admin and the_invited_members %}
-                <div class="card mt-4">
-                    <div class="card-header">
-                        <div class="row titlerow"><div class="col-12">
-                            {% trans "Invited Members" %} <span class="badge badge-pill badge-secondary">{{the_invited_members.all|length}}</span>
-                        </div></div>
-                    </div>
-                    <div class="card-body">
-                        {% for m in the_invited_members %}
-                        <div class="row">
-                            <div class="col-md-4 col-sm-4 col-4">
-                                {{ m.email }}
-                            </div>
-                            <div class="col-md-3 col-sm-3 col-3">
-                                <a href="{% url 'member-invite-delete' pk=m.id %}">{% trans "forget the invite" %}</a>
-                            </div>
-                        </div>
-                        {% endfor %}
-                    </div>
-                </div> <!-- panel -->
-            {% endif %}
-            <div class="card mt-4">
-                <div class="card-header">
-                    <div class="row titlerow">
-                        {% if band.sections.populated|length == 1 %}
-                            <div class="col-sm-8 col-6">
-                                {% trans "Members" %}
-                                {% if the_user_is_band_admin or request.user.is_superuser %}
-                                    <button class="btn btn-primary btn-sm" onclick="toggle_names(); return false;"><i class="fas fa-sync fs-lg"></i></button>
-                                {% endif %}
-                            </div>
-                        {% else %}
-                            <div class="col-md-3 d-none d-md-block">
-                                {% trans "Sections" %}
-                            </div>
-                            <div class="col-md-5 col-sm-8 col-6">
-                                {% trans "Members" %}
-                                    {% if the_user_is_band_admin or request.user.is_superuser %}
-                                        <a class="btn btn-primary btn-sm" href="#" onclick="toggle_names(); return false;"><i class="fas fa-sync fs-lg"></i></a>
-                                    {% endif %}
-                            </div>
-                        {% endif %}
-                        {% if the_user_is_band_admin or request.user.is_superuser %}
-                            <div class="col-sm-4 col-6 pr-0 text-right">
-                                <a class="btn btn-primary btn-sm" href="{% url 'member-invite' bk=band.id %}">{% trans "Invite Members" %}</a>
-                            </div>
-                        {% endif %}
-                    </div>
+                    <div class="row titlerow" id="pending-members"><div class="col-12">
+                        {% trans "Pending Members" %} <span class="badge badge-pill badge-secondary">{{the_pending_members.all|length}}</span>
+                    </div></div>
                 </div>
                 <div class="card-body">
-                    <div class="row">
-                        <div class="col-12" id="sectionlist">
-                            {% for s in band.sections.populated %}
-                                <div class="row"
-                                     id="section{{forloop.counter0}}"
-                                     hx-get="{% url 'section-members' pk=band.id sk=s.id %}"
-                                     hx-trigger="load"
-                                     style="padding-top: 5px; padding-bottom: 5px; {% cycle '' 'background:#f5f5f5;' %}">
-                            		<div class="col-12">
-                            			<i class="fas fa-spinner fa-pulse fa-lg"></i>
-                            		</div>
-                           	    </div>
-                        	{% endfor %}
+                    {% for assoc in the_pending_members %}
+                    <div class="row" style="padding-top: 5px; padding-bottom: 5px; {% cycle '' 'background:#f5f5f5;' %}">
+                        <div class="col-md-2 col-sm-2 col-12">
+                            <a href="{% url 'member-detail' pk=assoc.member.id %}">{{ assoc.member.display_name|escape }}</a>
+                        </div>
+                        <div class="col-md-4 col-sm-4 col-12">
+                            {{ assoc.member.email|escape }}
+                        </div>
+                        <div class="col-md-6 col-sm-6 col-12">
+                            <button class="btn btn-primary btn-sm"
+                                hx-ext="reload-page"
+                                hx-post="{% url 'assoc-confirm' ak=assoc.id %}"
+                                hx-swap="none">
+                                {% trans "yes, confirm member!" %}
+                                <span class="htmx-indicator">
+                                    <i class="fa fa-spinner fa-spin fa-lg"></i>
+                                </span>    
+                            </button>
+                            <button class="btn btn-secondary btn-sm"
+                                hx-ext="reload-page"
+                                hx-post="{% url 'assoc-delete' ak=assoc.id %}"
+                                hx-swap="none">
+                                {% trans "no, reject!" %}
+                                <span class="htmx-indicator">
+                                    <i class="fa fa-spinner fa-spin fa-lg"></i>
+                                </span>    
+                            </button>
                         </div>
                     </div>
-                    {% if request.user.is_superuser or the_user_is_band_admin %}
-                        <div class="row mt-2">
-                            <div class="col-12 justify-content-start">
-                                <a href="{% url 'band-section-setup' pk=band.id %}" class="btn btn-primary btn-sm" >{% trans "Set Up Sections" %}</a>
-                            </div>
+                    {% endfor %}
+                </div>
+            </div> <!-- panel -->
+        {% endif %}
+
+        {% if the_user_is_band_admin and the_invited_members %}
+            <div class="card mt-4">
+                <div class="card-header">
+                    <div class="row titlerow"><div class="col-12">
+                        {% trans "Invited Members" %} <span class="badge badge-pill badge-secondary">{{the_invited_members.all|length}}</span>
+                    </div></div>
+                </div>
+                <div class="card-body">
+                    {% for m in the_invited_members %}
+                    <div class="row">
+                        <div class="col-md-4 col-sm-4 col-4">
+                            {{ m.email }}
+                        </div>
+                        <div class="col-md-3 col-sm-3 col-3">
+                            <a href="{% url 'member-invite-delete' pk=m.id %}">{% trans "forget the invite" %}</a>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div> <!-- panel -->
+        {% endif %}
+        <div class="card mt-4">
+            <div class="card-header">
+                <div class="row titlerow">
+                    {% if band.sections.populated|length == 1 %}
+                        <div class="col-sm-8 col-6">
+                            {% trans "Members" %}
+                            {% if the_user_is_band_admin or request.user.is_superuser %}
+                                <button class="btn btn-primary btn-sm" onclick="toggle_names(); return false;"><i class="fas fa-sync fs-lg"></i></button>
+                            {% endif %}
+                        </div>
+                    {% else %}
+                        <div class="col-md-3 d-none d-md-block">
+                            {% trans "Sections" %}
+                        </div>
+                        <div class="col-md-5 col-sm-8 col-6">
+                            {% trans "Members" %}
+                                {% if the_user_is_band_admin or request.user.is_superuser %}
+                                    <a class="btn btn-primary btn-sm" href="#" onclick="toggle_names(); return false;"><i class="fas fa-sync fs-lg"></i></a>
+                                {% endif %}
+                        </div>
+                    {% endif %}
+                    {% if the_user_is_band_admin or request.user.is_superuser %}
+                        <div class="col-sm-4 col-6 pr-0 text-right">
+                            <a class="btn btn-primary btn-sm" href="{% url 'member-invite' bk=band.id %}">{% trans "Invite Members" %}</a>
                         </div>
                     {% endif %}
                 </div>
-            </div> <!-- panel -->
-
-            {% if the_user_is_band_admin or request.user.is_superuser %}
-                <div class="mt-4 card">
-                    <div class="card-header collapsed" data-toggle="collapse" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-                        <a class="card-title titlerow">
-                            {% trans "Member Admin" %}
-                        </a>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-12" id="sectionlist">
+                        {% for s in band.sections.populated %}
+                            <div class="row"
+                                    id="section{{forloop.counter0}}"
+                                    hx-get="{% url 'section-members' pk=band.id sk=s.id %}"
+                                    hx-trigger="load"
+                                    style="padding-top: 5px; padding-bottom: 5px; {% cycle '' 'background:#f5f5f5;' %}">
+                                <div class="col-12">
+                                    <i class="fas fa-spinner fa-pulse fa-lg"></i>
+                                </div>
+                            </div>
+                        {% endfor %}
                     </div>
-                    <div id="collapseOne" class="collapse card-body" role="tabpanel" aria-labelledby="headingOne">
-                        <div class="row">
-                            <div class="col-12">
-                                <a class="btn btn-primary btn-sm" href="{% url 'member-invite' bk=band.id %}">{% trans "Invite Members" %}</a>
-                                <a class="btn btn-primary btn-sm" href="{% url 'member-spreadsheet' pk=band.id %}">{% trans "Download Member List" %}</a>
-                                <a class="btn btn-primary btn-sm" href="{% url 'member-emails' pk=band.id %}">{% trans "Get Member Emails" %}</a>
-
-                            </div>
-                            <hr>
+                </div>
+                {% if request.user.is_superuser or the_user_is_band_admin %}
+                    <div class="row mt-2">
+                        <div class="col-12 justify-content-start">
+                            <a href="{% url 'band-section-setup' pk=band.id %}" class="btn btn-primary btn-sm" >{% trans "Set Up Sections" %}</a>
                         </div>
-                        <div class="row">
-                            <div class="col-12" id="memberlist" hx-get="{% url 'all-members' pk=band.id %}" hx-trigger="load">
-                                <i class="fas fa-spinner fa-pulse fa-lg"></i>
-                            </div>
+                    </div>
+                {% endif %}
+            </div>
+        </div> <!-- panel -->
+
+        {% if the_user_is_band_admin or request.user.is_superuser %}
+            <div class="mt-4 card">
+                <div class="card-header collapsed" data-toggle="collapse" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+                    <a class="card-title titlerow">
+                        {% trans "Member Admin" %}
+                    </a>
+                </div>
+                <div id="collapseOne" class="collapse card-body" role="tabpanel" aria-labelledby="headingOne">
+                    <div class="row">
+                        <div class="col-12">
+                            <a class="btn btn-primary btn-sm" href="{% url 'member-invite' bk=band.id %}">{% trans "Invite Members" %}</a>
+                            <a class="btn btn-primary btn-sm" href="{% url 'member-spreadsheet' pk=band.id %}">{% trans "Download Member List" %}</a>
+                            <a class="btn btn-primary btn-sm" href="{% url 'member-emails' pk=band.id %}">{% trans "Get Member Emails" %}</a>
+
+                        </div>
+                        <hr>
+                    </div>
+                    <div class="row">
+                        <div class="col-12" id="memberlist" hx-get="{% url 'all-members' pk=band.id %}" hx-trigger="load">
+                            <i class="fas fa-spinner fa-pulse fa-lg"></i>
                         </div>
                     </div>
                 </div>
+            </div>
 
-                <div class="mt-4 card">
-                    <div class="card-header collapsed" data-toggle="collapse" href="#collapseTwo" aria-expanded="false" aria-controls="collapseOne">
-                        <a class="card-title titlerow">
-                            {% trans "Band Statistics" %}
-                        </a>
-                    </div>
-                    <div id="collapseTwo" class="collapse card-body" role="tabpanel" aria-labelledby="headingOne">
-                        <div class="row">
-                            <div class="col-12" id="bandstats" hx-get="{% url 'band-stats' pk=band.id %}" hx-trigger="load">
-                                <i class="fas fa-spinner fa-pulse fa-lg"></i>
-                            </div>
+            <div class="mt-4 card">
+                <div class="card-header collapsed" data-toggle="collapse" href="#collapseTwo" aria-expanded="false" aria-controls="collapseOne">
+                    <a class="card-title titlerow">
+                        {% trans "Band Statistics" %}
+                    </a>
+                </div>
+                <div id="collapseTwo" class="collapse card-body" role="tabpanel" aria-labelledby="headingOne">
+                    <div class="row">
+                        <div class="col-12" id="bandstats" hx-get="{% url 'band-stats' pk=band.id %}" hx-trigger="load">
+                            <i class="fas fa-spinner fa-pulse fa-lg"></i>
                         </div>
                     </div>
                 </div>
+            </div>
 
-            {% endif %}
         {% endif %}
     </div>
 </div>

--- a/templates/band/band_public.html
+++ b/templates/band/band_public.html
@@ -1,0 +1,176 @@
+{% extends 'base/go3base.html' %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Band Info" %}{% endblock title %}
+
+{% block headcontent %}
+
+{% endblock headcontent %}
+
+{% block content %}
+<div class="row">
+    <div class="mx-auto col-lg-8 col-md-10 col-12">
+
+        <div class="page-header">
+            {{ band.name }}
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <div class="row titlerow">
+                    <div class="col-4">
+                        {% trans "Info" %}
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-12">
+                        {% if band.description %}
+                            {{ band.description | linebreaksbr }}
+                        {% else %}
+                            {% trans "A Band of Mystery..." %}
+                        {% endif %}
+                    </div>
+                </div>
+                {% if band.hometown %}
+                    <div class="row mt-4">
+                        <div class="col-sm-3 col-12">{% trans "Hometown" %}</div>
+                        <div class="col-sm-9 col-12">
+                            <a href="http://maps.google.com?q={{band.hometown}}" target="new">{{ band.hometown }}</a>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if band.website %}
+                    <div class="row mt-4">
+                        <div class="col-sm-3 col-12">{% trans "Website" %}</div>
+                        <div class="col-sm-9 col-12">
+                            <a href="{{band.website|escape}}" target="new">{{band.website|escape}}</a>
+                        </div>
+                    </div>
+                {% endif %}
+            </div> <!-- card-body -->
+        </div> <!-- card -->
+
+        {% if the_images %}
+            <div class="card mt-4">
+                <div class="card-header">
+                    <div class="row titlerow">
+                        <div class="col-12">
+                            {% trans "Pictures Of Us" %}
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body" id="pictures">
+                    <div id="bandimages" class="carousel slide" data-ride="carousel">
+                      <div class="carousel-inner">
+                        {% for i in the_images %}
+                            <div class="carousel-item{% if forloop.counter == 1 %} active{% endif %}">
+                              <img class="d-block img-fluid" src="{{i}}">
+                            </div>
+                        {% endfor %}
+                      </div>
+                      <a class="carousel-control-prev" href="#bandimages" role="button" data-slide="prev">
+                        <i class="fas fa-chevron-left fa-2x" style="color:gray;" aria-hidden="true"></i>
+                        <span class="sr-only">Previous</span>
+                      </a>
+                      <a class="carousel-control-next" href="#bandimages" role="button" data-slide="next">
+                        <i class="fas fa-chevron-right fa-2x" style="color:gray;" aria-hidden="true"></i>
+                        <span class="sr-only">Next</span>
+                      </a>
+                    </div>
+
+                </div>
+            </div>
+        {% endif %}
+        {% if band.share_gigs %}
+            <div class="card mt-4">
+                <div class="card-header">
+                    <div class="row titlerow">
+                        <div class="col-12">
+                            {% trans "Upcoming Gigs" %}
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body" id="upcoming-gigs" hx-get="{% url 'band-public-gigs' pk=band.id %}" hx-trigger="load">
+                    <div class="row">
+                        <i class="fas fa-spinner fa-pulse fa-lg"></i>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock content %}
+
+{% block modal %}
+{% endblock modal %}
+
+{% block localscripts %}
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="{% static 'js/band_stats.js' %}"></script>
+{% comment %}
+<script src="/js/jquery.validate.js"></script>
+{% endcomment %}
+<script src="{% static "js/plan_buttons.js" %}"></script>
+
+<script>
+
+// TODO
+function updateUpcoming() {
+    if (document.getElementById('upcoming-gigs')) {
+        $.post('/band_get_upcoming',
+            {
+                bk: '{{ band.id }}'
+            },
+            function(responseTxt,statusTxt,xhr){
+                if(statusTxt=="success")
+                    document.getElementById('upcoming-gigs').innerHTML=responseTxt;
+                if(statusTxt=="error")
+                    alert("Error: "+xhr.status+": "+xhr.statusText);
+            });
+    }
+}
+
+// TODO
+function updatePublic() {
+    if (document.getElementById('public-members')) {
+        $.post('/band_get_public_members',
+            {
+                bk: '{{ band.id }}'
+            },
+            function(responseTxt,statusTxt,xhr){
+                if(statusTxt=="success")
+                    document.getElementById('public-members').innerHTML=responseTxt;
+                if(statusTxt=="error")
+                    alert("Error: "+xhr.status+": "+xhr.statusText);
+            });
+    }
+}
+
+var nicknames=true;
+function toggle_names() {
+    nicknames = !nicknames;
+    if (nicknames) {
+        $('.the_nickname').show();
+        $('.the_longname').hide();
+    } else {
+        $('.the_nickname').hide();
+        $('.the_longname').show();
+    };
+}
+
+htmx.on("htmx:afterSettle", function(evt) {
+    if (evt['target'].id == 'bandstats') {
+        initStats('bandcharts');
+    }
+});
+
+
+$(document).ready(function() {
+    updateUpcoming();
+    updatePublic();
+});
+</script>
+{% endblock localscripts %}


### PR DESCRIPTION
Split up the detail view from the public view. This is useful because if you're not logged in but are actually a member, going to the detail view should prompt you to log in and then take you there. If the public view and detail view are the same view, you don't get to log in, just see the public view.