### PR TITLE
added check to make sure bands don't end up with identical condensed …

### DIFF
--- a/band/signals.py
+++ b/band/signals.py
@@ -16,14 +16,27 @@
 """
 from django.db.models.signals import pre_save, post_save, pre_delete
 from django.dispatch import receiver
+from django.db.models import Q
 from .models import Band, Assoc, Section
 from .util import AssocStatusChoices
 from gig.models import Plan
 from gig.helpers import update_plan_default_section
+from unidecode import unidecode
 
 @receiver(pre_save, sender=Band)
 def set_condensed_name(sender, instance, **kwargs):
-    instance.condensed_name = ''.join(instance.name.split()).lower()
+
+    # take out non-ascii characters
+    cname = ''.join(instance.name.split()).lower()
+    cname = unidecode(cname)
+    count = Band.objects.filter(condensed_name=cname)
+    if instance.id:
+        # make sure we don't mean ourselves - this could happen if we're saving the band for another reason
+        count = count.filter(~Q(id=instance.id))
+    count = count.count()
+    if count > 0:
+        cname = f'{cname}{count}'
+    instance.condensed_name = cname
 
 @receiver(post_save, sender=Band)
 def set_default_section(sender, instance, created, **kwargs):

--- a/band/signals.py
+++ b/band/signals.py
@@ -21,7 +21,7 @@ from .models import Band, Assoc, Section
 from .util import AssocStatusChoices
 from gig.models import Plan
 from gig.helpers import update_plan_default_section
-from unidecode import unidecode
+from text_unidecode import unidecode
 
 @receiver(pre_save, sender=Band)
 def set_condensed_name(sender, instance, **kwargs):

--- a/band/tests.py
+++ b/band/tests.py
@@ -340,6 +340,26 @@ class MemberTests(TestCase):
         self.assertIsNone(do_delete_assoc(a))
 
 class BandTests(GigTestBase):
+    def test_condensed_name(self):
+        b1 = Band.objects.create(name="condense test")
+        self.assertEqual(b1.condensed_name, "condensetest")
+        
+        # fire the signal again but make sure it doesn't affect anything
+        b1.save()
+        self.assertEqual(b1.condensed_name, "condensetest")
+        
+        b2 = Band.objects.create(name="condense test")
+        self.assertNotEqual(b2.condensed_name, b1.condensed_name)
+        self.assertEqual(b2.condensed_name, "condensetest1")
+
+        # fire the signal again but make sure it doesn't affect anything
+        b2.save()
+        self.assertEqual(b2.condensed_name, "condensetest1")
+
+        # make sure we're only using ascii characters, too
+        b3 = Band.objects.create(name="fünny çharacters😀")
+        self.assertEqual(b3.condensed_name, "funnycharacters")
+
 
     def test_edit_permissions(self):
         self.assertTrue(self.band.is_editor(self.band_admin))


### PR DESCRIPTION
…names even if they have the same name.

This is so the public link, which uses condensed names, doesn't get confused.