### PR TITLE
link admin to live site

### DIFF
--- a/band/models.py
+++ b/band/models.py
@@ -127,6 +127,9 @@ class Band(models.Model):
             (~Q(enddate=None) & Q(enddate__lt=the_date))
         ).order_by('date')
 
+    def get_absolute_url(self):
+        from django.urls import reverse
+        return reverse("band-detail", kwargs={"pk": self.pk})
 
     def __str__(self):
         return self.name

--- a/member/models.py
+++ b/member/models.py
@@ -213,6 +213,10 @@ class Member(AbstractUser):
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = []
 
+    def get_absolute_url(self):
+        from django.urls import reverse
+        return reverse("member-detail", kwargs={"pk": self.pk})
+
     class Meta:
         permissions = (
             ("beta_tester", "Is A Beta Tester"),


### PR DESCRIPTION
added canonical URL functions so the admin page can link to the object on the live site