### PR TITLE
Add timezone back into caldav feed

### DIFF
--- a/band/forms.py
+++ b/band/forms.py
@@ -35,7 +35,7 @@ class BandForm(forms.ModelForm):
     class Meta:
         model = Band
         fields = ['name', 'shortname', 'hometown', 'description', 'member_links', 'website',
-            'new_member_message', 'thumbnail_img', 'images', 'default_language',
+            'new_member_message', 'thumbnail_img', 'images', 'default_language', 'timezone',
             'anyone_can_create_gigs', 'anyone_can_manage_gigs', 'share_gigs',
             'send_updates_by_default', 'rss_feed', 'simple_planning', 'plan_feedback']
 

--- a/gig/models.py
+++ b/gig/models.py
@@ -27,6 +27,7 @@ from .util import GigStatusChoices, PlanStatusChoices
 from member.util import MemberStatusChoices
 from django.utils.timezone import localtime
 from go3.datetime_without_timezone import DateTimeWithoutTimezoneField
+from pytz import timezone
 
 
 class GigsManager(models.Manager):
@@ -158,6 +159,13 @@ class AbstractEvent(models.Model):
     default_to_attending = models.BooleanField( default=False )
 
     trashed_date = models.DateTimeField( blank=True, null=True )
+
+    def add_tz(self, d):
+        """ return the passed-in date with a timezone added. For now just use the band's tz """
+        tzname = self.band.timezone
+        tz = timezone(tzname)
+        return tz.localize(d)
+
 
     @property
     def is_in_trash(self):

--- a/gig/models.py
+++ b/gig/models.py
@@ -164,7 +164,7 @@ class AbstractEvent(models.Model):
         """ return the passed-in date with a timezone added. For now just use the band's tz """
         tzname = self.band.timezone
         tz = timezone(tzname)
-        return tz.localize(d)
+        return d.replace(tzinfo=tz)
 
 
     @property

--- a/lib/caldav.py
+++ b/lib/caldav.py
@@ -89,11 +89,9 @@ def make_calfeed(the_title, the_events, the_language, the_uid, is_for_band=False
                 event.add('dtend', enddate, {'value': 'DATE'})
             else:
                 setdate = e.setdate if (is_for_band and e.setdate) else e.date
-                setdate.replace(tzinfo=None)
-                event.add('dtstart', setdate)
+                event.add('dtstart', e.add_tz(setdate))
                 enddate = e.enddate if e.enddate else e.date + timedelta(hours=1)
-                enddate.replace(tzinfo=None)
-                event.add('dtend', enddate)
+                event.add('dtend', e.add_tz(enddate))
             event.add('description', _make_description(e))
             event.add('location', e.address)
             event.add(

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -114,6 +114,18 @@ class CaldavTest(TestCase):
         self.assertTrue(cf.find(b'DTSTART:20200229T143000')==-1)
         self.assertTrue(cf.find(b'DTSTART:20200229T153000')>0)
 
+    def test_calfeed_timezone(self):
+        self.testgig.enddate = self.testgig.date + timedelta(hours=2)
+        self.testgig.save()
+        self.band.timezone = 'US/Eastern'
+        self.band.save()
+        # first, a gig without a set time should show the call time
+        cf = make_calfeed(b'flim-flam', self.band.gigs.all(),self.joeuser.preferences.language, 
+                          self.band.pub_cal_feed_id, is_for_band=True)
+        self.assertTrue(cf.find(b'DTSTART;TZID=US/Eastern:20200229T143000')>0)
+        self.assertTrue(cf.find(b'DTEND;TZID=US/Eastern:20200229T163000')>0)
+
+
 
     def test_calfeed_event_full_day(self):
         self.testgig.is_full_day = True


### PR DESCRIPTION
It turns out that google calendar (at least) really does need a timezone. As a result, the recent move away from timezones has broken the calfeed - every event is assumed by google to be in UTC. This PR adds back the ability for a band to edit its timezone, and uses that timezone in the calfeed. THis may not be the long-term answer but it should fix the calfeeds for now.
