### PR TITLE
fix for "natural date" display on agenda and gig details

### DIFF
--- a/templates/agenda/agenda_plan_edit.html
+++ b/templates/agenda/agenda_plan_edit.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load humanize %}
+{% load tz %}
 
 {% comment %}
 {% with assoc=plan.assoc %}
@@ -17,7 +18,7 @@
     <div class="row" style="position:relative; left:5px;">
 {% endif %}
     <div class="col-sm-12 col-md-3">
-        {{ gig.date|naturalday:"SHORT_DATE_FORMAT"|capfirst }} {{ gig.date|date:"D" }}
+        {{ gig.date|timezone:user.preferences.current_timezone|naturalday:"SHORT_DATE_FORMAT"|capfirst }} {{ gig.date|date:"D" }}
 {% comment %}
 Add the day of week to the short_date_format - can just append D?
 {% endcomment %}

--- a/templates/gig/gig_detail.html
+++ b/templates/gig/gig_detail.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load gig_extras %}
 {% load humanize %}
+{% load tz %}
 
 {% block title %}{% trans "Gig Info" %}{% endblock title %}
 
@@ -83,9 +84,9 @@
                 <div class="row">&nbsp;</div>
                 <div class="row">
                     <div class="col-2"><i class="fas fa-calendar"></i></div>
-                    <div class="col-10">{{ gig.date|naturalday:"SHORT_DATE_FORMAT"|capfirst }} ({{ gig.date|date:"l" }})
+                    <div class="col-10">{{ gig.date|timezone:user.preferences.current_timezone|naturalday:"SHORT_DATE_FORMAT"|capfirst }} ({{ gig.date|date:"l" }})
                         {% if multi_day_gig %}
-                            - {{ gig.enddate|naturalday:"SHORT_DATE_FORMAT"|capfirst }} ({{ gig.enddate|date:"l" }})
+                            - {{ gig.enddate|timezone:user.preferences.current_timezone|naturalday:"SHORT_DATE_FORMAT"|capfirst }} ({{ gig.enddate|date:"l" }})
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
"Natural date" display (ie "Tomorrow") on the agenda and gig details pages were assuming UTC since the timezones are not turned on. There's a template tag that forces the timezone and I've set it here to use the user's current timezone.