### PR TITLE
Add 'hide_from_calendar' field to GigSchema and update tests

### DIFF
--- a/gig/api.py
+++ b/gig/api.py
@@ -49,6 +49,7 @@ class GigSchema(ModelSchema):
             "address",
             "is_archived",
             "is_private",
+            "hide_from_calendar",
         ]
 
     @staticmethod

--- a/gig/tests.py
+++ b/gig/tests.py
@@ -1352,7 +1352,9 @@ class TestGigAPI(GigTestBase):
         data = response.json()
         self.assertEqual(data.get("count"), 1)
         self.assertEqual(data.get("gigs")[0].get("gig_status"), status_label)
-        self.assertEqual(data.get("gigs")[0].get("title"), f"{status_label} Gig-xyzzy")
+        self.assertEqual(data.get("gigs")[0].get("title"), f"{status_label} Gig-xyzzy")        
+        self.assertIn("hide_from_calendar", data.get("gigs")[0])
+        self.assertEqual(data.get("gigs")[0].get("hide_from_calendar"), False)
 
     def test_gig_status_filter(self):
         for status in GigStatusChoices.choices:


### PR DESCRIPTION
I would like to add this field to the API so that the band website can automatically show all confirmed public gigs please.