### PR TITLE
spelling fix: Lanuage -> Language for US and UK english

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -1693,12 +1693,6 @@ msgstr "Archivierte Termine Info"
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: templates/member/member_detail.html:204
-#, fuzzy
-#| msgid "Language"
-msgid "Lanuage"
-msgstr "Sprache"
-
 #: templates/member/member_detail.html:210
 msgid "Timezone"
 msgstr ""

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -1558,10 +1558,6 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: templates/member/member_detail.html:204
-msgid "Lanuage"
-msgstr ""
-
 #: templates/member/member_detail.html:210
 msgid "Timezone"
 msgstr ""

--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -1618,10 +1618,6 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: templates/member/member_detail.html:204
-msgid "Lanuage"
-msgstr ""
-
 #: templates/member/member_detail.html:210
 msgid "Timezone"
 msgstr ""

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -1852,10 +1852,6 @@ msgstr "Eventos descartados de"
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: templates/member/member_detail.html:204
-msgid "Lanuage"
-msgstr ""
-
 #: templates/member/member_detail.html:210
 msgid "Timezone"
 msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1697,12 +1697,6 @@ msgstr "Infos du concert (archive)"
 msgid "Preferences"
 msgstr "Préférences"
 
-#: templates/member/member_detail.html:204
-#, fuzzy
-#| msgid "Language"
-msgid "Lanuage"
-msgstr "Langue"
-
 #: templates/member/member_detail.html:210
 msgid "Timezone"
 msgstr ""

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -1697,12 +1697,6 @@ msgstr "Info suonata archiviata"
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: templates/member/member_detail.html:204
-#, fuzzy
-#| msgid "Language"
-msgid "Lanuage"
-msgstr "Lingua"
-
 #: templates/member/member_detail.html:210
 msgid "Timezone"
 msgstr ""

--- a/templates/member/member_detail.html
+++ b/templates/member/member_detail.html
@@ -201,7 +201,7 @@
                 <div class="card-body">
                     <div class="row">
                         {% get_language_info for member.preferences.language as lang %}
-                        <div class="d-none d-sm-inline col-sm-3">{% trans "Lanuage" %}:</div>
+                        <div class="d-none d-sm-inline col-sm-3">{% trans "Language" %}:</div>
                         <div class="d-none d-sm-inline col-sm-9">{{ lang.name_local|title }}</div>
                         <div class="col-12 d-sm-none">{% trans "Language" %}: {{ lang.name_local|title }}</div>
                     </div>


### PR DESCRIPTION
Fix spelling "Lanuage" -> "Language" on member detail page.
remove now duplicate entry in all translation files ("Language" key already existed and had correct spelling)
All languages checked that "Lanuage" and "Language" translated the same.