### PR TITLE
Fix displaying calendar height on mobile

### DIFF
--- a/templates/agenda/calendar.html
+++ b/templates/agenda/calendar.html
@@ -80,6 +80,7 @@
             //     },
             // },
             eventSourceSuccess: calCallback,
+            height: 'auto',
         });
         calendar.render();
     });


### PR DESCRIPTION
Julie reported: "When i try to go forward it flips to November, like Oct has 18 days."

<img width="828" height="1792" alt="IMG_2840" src="https://github.com/user-attachments/assets/edd6166c-726e-4f71-a013-b46f24d90ef0" />

Turns out the calendar rendering was getting cut off. The full calendar was there, but you had to scroll it. This PR fixes that.