### PR TITLE
Upgrade lazy-object-proxy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ icalendar==5.0.12
 idna==3.7
 isort==5.9.3
 Jinja2==3.1.6
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.12.0
 Markdown==3.5.2
 MarkupSafe==2.0.1
 mccabe==0.6.1


### PR DESCRIPTION
Hoping this fixes the build issue seen in Github Actions: "ModuleNotFoundError: No module named pkg_resources"