### PR TITLE
made related objects readonly so admin does not time out

### DIFF
--- a/band/admin.py
+++ b/band/admin.py
@@ -35,6 +35,7 @@ class AssocAdmin(admin.ModelAdmin):
     list_display = (_model_str,'join_date')
     search_fields=['member__username', 'member__nickname', 'member__email', 'band__name']
     list_filter = ('is_admin',)
+    readonly_fields = ('default_section','member','band',)
 
 admin.site.register(Section)
 


### PR DESCRIPTION
When loading an 'assoc' object the admin page on the live site times out. Here I make the member, band, and default section all read-only which should speed things up.