### PR TITLE
ignore rsvp date check if it hasn't changed or if we're past the old rsvp date

### DIFF
--- a/gig/forms.py
+++ b/gig/forms.py
@@ -191,10 +191,17 @@ class GigForm(forms.ModelForm):
                 z = pytz.timezone(self.band.timezone)
                 rsvp_by_date = timezone.make_aware(rsvp_by_date, z)
                 
-                # Skip the RSVP date validation if the date has not changed or if the gig is cancelled
-                if (self.instance.rsvp_by_date != rsvp_by_date.date() 
-                    if rsvp_by_date else None) and \
-                    (not self.cleaned_data['status']==GigStatusChoices.CANCELED):
+                # Skip the RSVP date validation if the date has not changed or if the
+                # edit is happening after the RSVP date
+
+
+                # if there is no rsvp date but now there is one
+                # or if these is one and the new one is different
+
+                if self.instance.rsvp_by_date is None or \
+                    self.instance.rsvp_by_date != rsvp_by_date:
+                # if (self.instance.rsvp_by_date) and \
+                #     (self.instance.rsvp_by_date != rsvp_by_date.date() if rsvp_by_date else None):
                     now = timezone.now()
                     if rsvp_by_date < now:
                         self.add_error('rsvp_date', ValidationError(_('RSVP deadline must be in the future'), code='invalid rsvp date'))


### PR DESCRIPTION
Basically, if you're making an edit past an RSVP date, don't complain that the date is off. Only complain if the RSVP date is new and either in the past or past the gig date.