### PR TITLE
Firewall

### DIFF
--- a/firewall/apps.py
+++ b/firewall/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class FirewallConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'firewall'

--- a/firewall/helpers.py
+++ b/firewall/helpers.py
@@ -1,0 +1,34 @@
+"""
+    This file is part of Gig-o-Matic
+
+    Gig-o-Matic is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from django.http import HttpResponseForbidden, HttpResponseRedirect
+from django.contrib.auth.decorators import login_required
+from .middleware import FIREWALL_STATS
+
+def superuser_required(func):
+    def decorated(request, *args, **kw):
+        if not (request.user.is_superuser):
+            return HttpResponseForbidden()
+        return func(request, *args, **kw)
+    return decorated
+
+@login_required
+@superuser_required
+def reset_firewall_stats(request):
+    FIREWALL_STATS['filtered files'] = 0
+    FIREWALL_STATS['404 paths'] = {}
+    return HttpResponseRedirect('/admin/firewall')

--- a/firewall/helpers.py
+++ b/firewall/helpers.py
@@ -17,7 +17,6 @@
 
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
-from .middleware import FIREWALL_STATS
 
 def superuser_required(func):
     def decorated(request, *args, **kw):
@@ -29,6 +28,20 @@ def superuser_required(func):
 @login_required
 @superuser_required
 def reset_firewall_stats(request):
-    FIREWALL_STATS['filtered files'] = 0
-    FIREWALL_STATS['404 paths'] = {}
+    firewall = request.firewall
+    firewall.reset()
+    return HttpResponseRedirect('/admin/firewall')
+
+@login_required
+@superuser_required
+def firewall_on(request):
+    firewall = request.firewall
+    firewall.firewall_on = True
+    return HttpResponseRedirect('/admin/firewall')
+
+@login_required
+@superuser_required
+def firewall_off(request):
+    firewall = request.firewall
+    firewall.firewall_on = False
     return HttpResponseRedirect('/admin/firewall')

--- a/firewall/middleware.py
+++ b/firewall/middleware.py
@@ -16,50 +16,58 @@
 """
 
 # A simple firewall middleware meant to ward off standard kinds of attacks
+from datetime import datetime
 from django.http import HttpResponseForbidden
-from go3.settings import FIREWALL_ON
+from go3.settings import START_FIREWALL
+
 
 BAD_FILE_EXTENSIONS = ['php','env']
 BAD_FILE_PREFIXES = ['/wp-admin', '/favicon.ico', '/apple-touch-icon']
-FIREWALL_STATS = {
-    'filtered files': 0,
-    '404 paths': {},
-}
 
 class FirewallMiddleware:
+
+    firewall_on = START_FIREWALL
+    filtered_files = 0
+    paths_404 = {}
+    last_reset = datetime.now()
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        global FILES_FILTERED
-        global PATH_404
 
-        if FIREWALL_ON:
+        if self.firewall_on:
             # check for files that should not be requested
             file_extension = request.path.split('/')[-1].split('.')[-1].strip()
             if file_extension in BAD_FILE_EXTENSIONS:
-                FIREWALL_STATS['filtered files'] += 1
+                self.filtered_files += 1
                 return HttpResponseForbidden()
 
             for pref in BAD_FILE_PREFIXES:
                 if request.path.startswith(pref):
-                    FIREWALL_STATS['filtered files'] += 1
+                    self.filtered_files += 1
                     return HttpResponseForbidden()
 
+        if request.path.startswith('/admin/firewall/') or request.path.startswith('/firewall/'):
+            request.firewall = self # pass this on the request so it can be used later
         response = self.get_response(request)
 
-
-        if FIREWALL_ON:
+        if self.firewall_on:
             # did we get a 404? If so, remember what it was
             if response.status_code == 404:
-                if request.path in FIREWALL_STATS['404 paths']:
-                    FIREWALL_STATS['404 paths'][request.path] += 1
+                if request.path in self.paths_404:
+                    self.paths_404[request.path] += 1
                 else:
-                    FIREWALL_STATS['404 paths'][request.path] = 1
+                    self.paths_404[request.path] = 1
 
-            while len(FIREWALL_STATS['404 paths'])>200:
-                # just drop some
-                FIREWALL_STATS['404 paths'].popitem()
+                    while len(self.paths_404)>200:
+                        # just drop some
+                        self.paths_404.popitem()
 
         return response
+
+    def reset(self):
+        self.filtered_files = 0
+        self.paths_404 = {}
+        self.last_reset = datetime.now()
+

--- a/firewall/middleware.py
+++ b/firewall/middleware.py
@@ -29,6 +29,7 @@ class FirewallMiddleware:
     firewall_on = START_FIREWALL
     filtered_files = 0
     paths_404 = {}
+    ips_404 = {}
     last_reset = datetime.now()
 
     def __init__(self, get_response):
@@ -64,10 +65,29 @@ class FirewallMiddleware:
                         # just drop some
                         self.paths_404.popitem()
 
+                ip = self.get_user_ip(request)
+                if ip in self.ips_404:
+                    self.ips_404[ip] += 1
+                else:
+                    self.ips_404[ip] = 1
+
+                while len(self.ips_404)>200:
+                    # just drop some
+                    self.ips_404.popitem()
+
         return response
 
     def reset(self):
         self.filtered_files = 0
         self.paths_404 = {}
+        self.ips_404 = {}
         self.last_reset = datetime.now()
 
+
+    def get_user_ip(self, request):
+        x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+        if x_forwarded_for:
+            ip = x_forwarded_for.split(',')[0].strip()
+        else:
+            ip = request.META.get('REMOTE_ADDR')
+        return ip

--- a/firewall/middleware.py
+++ b/firewall/middleware.py
@@ -1,0 +1,54 @@
+"""
+    This file is part of Gig-o-Matic
+
+    Gig-o-Matic is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+# A simple firewall middleware meant to ward off standard kinds of attacks
+from django.http import HttpResponseForbidden
+from go3.settings import FIREWALL_ON
+
+BAD_FILE_EXTENSIONS = ['php','env']
+BAD_FILE_PREFIXES = ['/wp-admin', '/favicon.ico', '/apple-touch-icon']
+PATH_404 = {}
+
+class FirewallMiddleware:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+
+        if FIREWALL_ON:
+            # check for files that should not be requested
+            file_extension = request.path.split('/')[-1].split('.')[-1].strip()
+            if file_extension in BAD_FILE_EXTENSIONS:
+                return HttpResponseForbidden()
+
+            for pref in BAD_FILE_PREFIXES:
+                if request.path.startswith(pref):
+                    return HttpResponseForbidden()
+
+        response = self.get_response(request)
+
+
+        if FIREWALL_ON:
+            # did we get a 404? If so, remember what it was
+            if response.status_code == 404:
+                if request.path in PATH_404:
+                    PATH_404[request.path] += 1
+                else:
+                    PATH_404[request.path] = 1
+
+        return response

--- a/firewall/middleware.py
+++ b/firewall/middleware.py
@@ -21,7 +21,10 @@ from go3.settings import FIREWALL_ON
 
 BAD_FILE_EXTENSIONS = ['php','env']
 BAD_FILE_PREFIXES = ['/wp-admin', '/favicon.ico', '/apple-touch-icon']
-PATH_404 = {}
+FIREWALL_STATS = {
+    'filtered files': 0,
+    '404 paths': {},
+}
 
 class FirewallMiddleware:
 
@@ -29,15 +32,19 @@ class FirewallMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        global FILES_FILTERED
+        global PATH_404
 
         if FIREWALL_ON:
             # check for files that should not be requested
             file_extension = request.path.split('/')[-1].split('.')[-1].strip()
             if file_extension in BAD_FILE_EXTENSIONS:
+                FIREWALL_STATS['filtered files'] += 1
                 return HttpResponseForbidden()
 
             for pref in BAD_FILE_PREFIXES:
                 if request.path.startswith(pref):
+                    FIREWALL_STATS['filtered files'] += 1
                     return HttpResponseForbidden()
 
         response = self.get_response(request)
@@ -46,13 +53,13 @@ class FirewallMiddleware:
         if FIREWALL_ON:
             # did we get a 404? If so, remember what it was
             if response.status_code == 404:
-                if request.path in PATH_404:
-                    PATH_404[request.path] += 1
+                if request.path in FIREWALL_STATS['404 paths']:
+                    FIREWALL_STATS['404 paths'][request.path] += 1
                 else:
-                    PATH_404[request.path] = 1
+                    FIREWALL_STATS['404 paths'][request.path] = 1
 
-            while len(PATH_404)>1:
+            while len(FIREWALL_STATS['404 paths'])>200:
                 # just drop some
-                PATH_404.popitem()
+                FIREWALL_STATS['404 paths'].popitem()
 
         return response

--- a/firewall/middleware.py
+++ b/firewall/middleware.py
@@ -94,5 +94,5 @@ class FirewallMiddleware:
         # else:
         #     ip = request.META.get('REMOTE_ADDR')
         # return ip
-        ip, trusted_route = self.ipw.get_client_ip(request.META)
+        ip, _ = self.ipw.get_client_ip(request.META)
         return ip

--- a/firewall/middleware.py
+++ b/firewall/middleware.py
@@ -51,4 +51,8 @@ class FirewallMiddleware:
                 else:
                     PATH_404[request.path] = 1
 
+            while len(PATH_404)>1:
+                # just drop some
+                PATH_404.popitem()
+
         return response

--- a/firewall/middleware.py
+++ b/firewall/middleware.py
@@ -19,6 +19,7 @@
 from datetime import datetime
 from django.http import HttpResponseForbidden
 from go3.settings import START_FIREWALL
+from python_ipware import IpWare
 
 
 BAD_FILE_EXTENSIONS = ['php','env']
@@ -31,6 +32,8 @@ class FirewallMiddleware:
     paths_404 = {}
     ips_404 = {}
     last_reset = datetime.now()
+
+    ipw = IpWare()
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -85,9 +88,11 @@ class FirewallMiddleware:
 
 
     def get_user_ip(self, request):
-        x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
-        if x_forwarded_for:
-            ip = x_forwarded_for.split(',')[0].strip()
-        else:
-            ip = request.META.get('REMOTE_ADDR')
+        # x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+        # if x_forwarded_for:
+        #     ip = x_forwarded_for.split(',')[0].strip()
+        # else:
+        #     ip = request.META.get('REMOTE_ADDR')
+        # return ip
+        ip, trusted_route = self.ipw.get_client_ip(request.META)
         return ip

--- a/firewall/tests.py
+++ b/firewall/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/firewall/urls.py
+++ b/firewall/urls.py
@@ -1,0 +1,25 @@
+"""
+    This file is part of Gig-o-Matic
+
+    Gig-o-Matic is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from django.urls import path
+from .helpers import reset_firewall_stats
+
+app_name = 'firewall'
+
+urlpatterns = [
+    path('reset_stats', reset_firewall_stats, name='reset_firewall_stats'),
+]

--- a/firewall/urls.py
+++ b/firewall/urls.py
@@ -16,10 +16,12 @@
 """
 
 from django.urls import path
-from .helpers import reset_firewall_stats
+from .helpers import reset_firewall_stats, firewall_on, firewall_off
 
 app_name = 'firewall'
 
 urlpatterns = [
     path('reset_stats', reset_firewall_stats, name='reset_firewall_stats'),
+    path('firewall_on', firewall_on, name='firewall_on'),
+    path('firewall_off', firewall_off, name='firewall_off'),
 ]

--- a/firewall/views.py
+++ b/firewall/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/go3/admin.py
+++ b/go3/admin.py
@@ -16,6 +16,8 @@
 """
 
 from django.contrib import admin
+from django.urls import path
+from django.template.response import TemplateResponse
 
 class Go3AdminSite(admin.AdminSite):
     site_header = 'Gig-o-Matic Admin'
@@ -40,4 +42,18 @@ class Go3AdminSite(admin.AdminSite):
                 new_app_list.append(a)
 
         return new_app_list
+    
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                'firewall/',
+                self.admin_view(self.firewall_view),
+                name='firewall',
+            ),
+        ]
+        return custom_urls + urls
  
+    def firewall_view(self, request):
+        context = {}
+        return TemplateResponse(request, 'admin/firewall.html', context)

--- a/go3/admin.py
+++ b/go3/admin.py
@@ -59,5 +59,6 @@ class Go3AdminSite(admin.AdminSite):
         context = {
             'bad_paths': [f'{p}: {c}' for p,c in FIREWALL_STATS['404 paths'].items()],
             'files_filtered': FIREWALL_STATS['filtered files'],
+            'has_permission': True,
         }
         return TemplateResponse(request, 'admin/firewall.html', context)

--- a/go3/admin.py
+++ b/go3/admin.py
@@ -18,7 +18,6 @@
 from django.contrib import admin
 from django.urls import path
 from django.template.response import TemplateResponse
-from firewall.middleware import FIREWALL_STATS
 
 class Go3AdminSite(admin.AdminSite):
     site_header = 'Gig-o-Matic Admin'
@@ -56,9 +55,12 @@ class Go3AdminSite(admin.AdminSite):
         return custom_urls + urls
  
     def firewall_view(self, request):
+        firewall = request.firewall
         context = {
-            'bad_paths': [f'{p}: {c}' for p,c in FIREWALL_STATS['404 paths'].items()],
-            'files_filtered': FIREWALL_STATS['filtered files'],
+            'bad_paths': [f'{p}: {c}' for p,c in firewall.paths_404.items()],
+            'files_filtered': firewall.filtered_files,
             'has_permission': True,
+            'firewall_on': firewall.firewall_on,
+            'last_reset': firewall.last_reset,
         }
         return TemplateResponse(request, 'admin/firewall.html', context)

--- a/go3/admin.py
+++ b/go3/admin.py
@@ -18,6 +18,7 @@
 from django.contrib import admin
 from django.urls import path
 from django.template.response import TemplateResponse
+from firewall.middleware import FIREWALL_STATS
 
 class Go3AdminSite(admin.AdminSite):
     site_header = 'Gig-o-Matic Admin'
@@ -55,5 +56,8 @@ class Go3AdminSite(admin.AdminSite):
         return custom_urls + urls
  
     def firewall_view(self, request):
-        context = {}
+        context = {
+            'bad_paths': [f'{p}: {c}' for p,c in FIREWALL_STATS['404 paths'].items()],
+            'files_filtered': FIREWALL_STATS['filtered files'],
+        }
         return TemplateResponse(request, 'admin/firewall.html', context)

--- a/go3/admin.py
+++ b/go3/admin.py
@@ -58,6 +58,7 @@ class Go3AdminSite(admin.AdminSite):
         firewall = request.firewall
         context = {
             'bad_paths': [f'{p}: {c}' for p,c in firewall.paths_404.items()],
+            'bad_ips': [f'{p}: {c}' for p,c in firewall.ips_404.items()],
             'files_filtered': firewall.filtered_files,
             'has_permission': True,
             'firewall_on': firewall.firewall_on,

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -88,6 +88,7 @@ INSTALLED_APPS = [
     "motd.apps.MotdConfig",
     "gig.apps.GigConfig",
     "agenda",
+    "firewall",
     "stats.apps.StatsConfig",
     "widget_tweaks",
     "go3.apps.Go3AdminConfig",

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -354,3 +354,4 @@ MARKDOWNIFY = {
     }
 }
 
+FIREWALL_ON = env('FIREWALL_ON',default=True)

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -107,6 +107,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "firewall.middleware.FirewallMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",

--- a/go3/settings.py
+++ b/go3/settings.py
@@ -355,4 +355,4 @@ MARKDOWNIFY = {
     }
 }
 
-FIREWALL_ON = env('FIREWALL_ON',default=True)
+START_FIREWALL = env('START_FIREWALL',default=True)

--- a/go3/urls.py
+++ b/go3/urls.py
@@ -55,6 +55,7 @@ urlpatterns = [
     path('help/', include('help.urls')),
     path('stats/', include('stats.urls')),
     path('admin/', admin.site.urls),
+    path('firewall/', include('firewall.urls', namespace='firewall')),
     path('migration/', include('migration.urls')),
     path('404',test404.as_view()),
     path('jsi18n/', JavaScriptCatalog.as_view(), name="javascript-catalog"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ pytest==9.0.3
 pytest-django==4.8.0
 python-dateutil==2.8.2
 python_http_client==3.3.2
+python-ipware==3.0.0
 pytz==2024.1
 requests==2.33.0
 rollbar==1.0.0

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -23,4 +23,3 @@ html[data-theme="light"], :root {
 {% endblock %}
 
 {% block nav-global %}{% endblock %}
-

--- a/templates/admin/firewall.html
+++ b/templates/admin/firewall.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/app_index.html" %}
 
 {% block title %}{% if subtitle %}{{ subtitle }} | {% endif %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
 
@@ -22,9 +22,23 @@ html[data-theme="light"], :root {
 {% endif %}
 {% endblock %}
 
-{% block nav-global %}{% endblock %}
-
-{% block userlinks %}
-<a href="firewall" class="section">Firewall</a> /
-{{ block.super }}
+{% block content %}
+<div>
+  <a class="button btn-primary" href="{% url 'firewall:reset_firewall_stats' %}">Reset Stats</a>
+</div>
+<br>
+<div>
+  Files Filtered: {{files_filtered}}
+</div>
+<br>
+<div>
+Bad Paths:
+<ul>
+{% for p in bad_paths %}
+<li>{{p}}</li>
+{% endfor %}
+</ul>
+</div>
 {% endblock %}
+
+{% block sidebar %}{% endblock %}

--- a/templates/admin/firewall.html
+++ b/templates/admin/firewall.html
@@ -46,6 +46,15 @@ Bad Paths:
 {% endfor %}
 </ul>
 </div>
+<br>
+<div>
+Bad IPs:
+<ul>
+{% for p in bad_ips %}
+<li>{{p}}</li>
+{% endfor %}
+</ul>
+</div>
 {% endblock %}
 
 {% block sidebar %}{% endblock %}

--- a/templates/admin/firewall.html
+++ b/templates/admin/firewall.html
@@ -24,11 +24,18 @@ html[data-theme="light"], :root {
 
 {% block content %}
 <div>
+  {% if firewall_on %}
+    <a class="button btn-primary" href="{% url 'firewall:firewall_off' %}">Turn Off</a>
+  {% else %}
+    <a class="button btn-primary" href="{% url 'firewall:firewall_on' %}">Turn On</a>
+  {% endif %}
   <a class="button btn-primary" href="{% url 'firewall:reset_firewall_stats' %}">Reset Stats</a>
 </div>
 <br>
+<div>Last Reset: {{last_reset}}</div>
+<br>
 <div>
-  Files Filtered: {{files_filtered}}
+  Files Filtered {{files_filtered}}
 </div>
 <br>
 <div>


### PR DESCRIPTION
First cut a really basic firewall. This just filters requests for php and wp_admin files - stuff we're seeing requests for but shouldn't try to serve. It also keeps track of requests that result in 404 - eventually, we can figure out where they come from and blacklist them. There's also an admin page (see the 'firewall' link on the admin site).