### PR TITLE
Fix for occasional members

### DIFF
--- a/templates/gig/gig_plan_edit.html
+++ b/templates/gig/gig_plan_edit.html
@@ -1,8 +1,7 @@
 {% load i18n %}
 
 {% with assoc=plan.assoc plan_member=plan.assoc.member band=plan.assoc.band %}
-
-<div class="row {% if plan.attending %}planattending{% else %}plannotattending{% endif %} {% if assoc.is_occasional and not plan.attending %}planoccasional{% endif %}">
+<div class="row {% if plan.attending %}planattending{% else %}plannotattending{% endif %} {% if assoc.is_occasional and not plan.attending and not plan_member == user %}planoccasional{% endif %}">
     <div class="col-4" style="display:flex; align-items:center;" >
         {% if plan_member.is_active %}
             <a href='/member/{{plan_member.id}}'>{{ plan_member.display_name }}</a>


### PR DESCRIPTION
Fixed so occasional members always see themselves in the default gig detail view when the view setting is "all" - that way they don't have to click through to "all + occasionals"
