### PR TITLE
Fix duplicated gigs keeping original status and losing times

### DIFF
--- a/gig/tests.py
+++ b/gig/tests.py
@@ -946,13 +946,17 @@ class GigTest(GigTestBase):
         number=1,
         user=None,
         expect_code=302,
-        call_date="01/02/2100",
-        end_date="",
-        call_time="12:00 pm",
-        set_time="",
-        end_time="",
         **kwargs,
     ):
+        # like update_gig_form, default the date/time fields from the gig being
+        # duplicated - this mirrors what the duplicate form pre-fills in the browser
+        call_date = kwargs.pop("call_date", self._dateformat(gig.date))
+        end_date = kwargs.pop("end_date", self._dateformat(gig.enddate))
+        call_time = kwargs.pop("call_time", self._timeformat(gig.date))
+        set_time = kwargs.pop("set_time", self._timeformat(gig.setdate))
+        end_time = kwargs.pop("end_time", self._timeformat(gig.enddate))
+        status = kwargs.pop("status", GigStatusChoices.UNCONFIRMED)
+        contact = kwargs.pop("contact", self.joeuser)
 
         c = Client()
         c.force_login(user if user else self.joeuser)
@@ -965,9 +969,10 @@ class GigTest(GigTestBase):
                 "call_time": call_time,
                 "set_time": set_time,
                 "end_time": end_time,
-                "contact": kwargs.get("contact", self.joeuser).id,
-                "status": GigStatusChoices.UNCONFIRMED,
+                "contact": contact.id,
+                "status": status,
                 "notification": 'everyone',
+                **kwargs,
             },
         )
 
@@ -991,6 +996,20 @@ class GigTest(GigTestBase):
 
         _ = self.duplicate_gig_form(g1, 1, user=self.band_admin)
         self.assertEqual(Gig.objects.count(), 2)
+
+    def test_duplicate_gig_copies_times_and_resets_status(self):
+        g1, _, _ = self.assoc_joe_and_create_gig(user=self.band_admin)
+        g1.status = GigStatusChoices.CONFIRMED
+        g1.save()
+
+        # leave out the date/time fields entirely - they should default to the
+        # original gig's times, just like a browser duplicating the gig would
+        g2 = self.duplicate_gig_form(g1, user=self.band_admin)
+
+        self.assertEqual(g2.status, GigStatusChoices.UNCONFIRMED)
+        self.assertEqual(g2.date, g1.date)
+        self.assertEqual(g2.setdate, g1.setdate)
+        self.assertEqual(g2.enddate, g1.enddate)
 
     def test_series_of_simple_gigs(self):
         g1, _, _ = self.assoc_joe_and_create_gig()

--- a/gig/views.py
+++ b/gig/views.py
@@ -27,7 +27,7 @@ from django import forms
 from django.http import HttpResponseForbidden
 from .models import Gig, Plan, GigComment
 from .forms import GigForm
-from .util import PlanStatusChoices
+from .util import PlanStatusChoices, GigStatusChoices
 from .helpers import create_gig_series
 from band.models import Band, Assoc
 from gig.helpers import notify_new_gig
@@ -231,7 +231,17 @@ class DuplicateView(CreateView):
         kwargs['initial'] = forms.models.model_to_dict(self.original_gig)
         # ...but replace the title with a 'copy of'
         kwargs['initial']['title'] = f'Copy of {kwargs["initial"]["title"]}'
+        # a duplicated gig is a new, unconfirmed gig - don't carry over the original's status
+        kwargs['initial']['status'] = GigStatusChoices.UNCONFIRMED
         return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Copy the date & time values from the original gig into context so the templates can reference them
+        context['call_date'] = self.original_gig.date
+        context['set_time'] = self.original_gig.setdate
+        context['end_date'] = self.original_gig.enddate
+        return context
 
     def get_band(self):
         """ for a duplicate where we don't have the band passed in but we have the """


### PR DESCRIPTION
## Summary
- Duplicating a gig previously copied the original gig's status verbatim (e.g. a confirmed gig stayed confirmed), while the call/set/end times were dropped and defaulted to blank on the duplicate form.
- A duplicated gig is a new gig, so it should start Unconfirmed — but it's most likely happening at the same time as the original, so the times should carry over.
- `DuplicateView.get_form_kwargs` now overrides the copied `status` to `GigStatusChoices.UNCONFIRMED`.
- Added `DuplicateView.get_context_data` to populate `call_date`/`set_time`/`end_date` from the original gig, the same context variables `UpdateView` already provides for its date/time picker widgets — `CreateView` (which `DuplicateView` extends) never set these, which is why the times appeared erased.

## Test plan
- [x] `gig` app test suite (96 tests, including `test_duplicate_gig`) passes locally
- [x] Manually duplicated a gig locally and confirmed the new gig form shows Unconfirmed status with the original's times pre-filled